### PR TITLE
Release infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,27 @@ jobs:
       - prepare
       - go/mod-download
       - go/mod-tidy-check
+        
+  imports-check:
+    executor: golang
+    steps:
+      - install-deps
+      - prepare
+      - run: go install golang.org/x/tools/cmd/goimports
+      - run: scripts/fiximports
+      - run: git --no-pager diff
+      - run: git --no-pager diff --quiet
+
+  cbor-gen-check:
+    executor: golang
+    steps:
+      - install-deps
+      - prepare
+      - run: go install golang.org/x/tools/cmd/goimports
+      - run: go install github.com/hannahhoward/cbor-gen-for
+      - run: go generate ./...
+      - run: git --no-pager diff
+      - run: git --no-pager diff --quiet
 
   test: &test
     description: |
@@ -159,3 +180,5 @@ workflows:
           args: "--new-from-rev origin/master"
       - test
       - mod-tidy-check
+      - cbor-gen-check
+      - imports-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,195 @@
+# go-data-transfer changelog
+
+# go-data-transfer 0.2.0
+
+Initial extracted release for Testnet Phase 2 (v0.1.0 + v0.1.1 were lotus tags prior to extraction)
+
+### Changelog
+
+- github.com/filecoin-project/go-data-transfer:
+  - Upgrade graphsync + ipld-prime (#49) ([filecoin-project/go-data-transfer#49](https://github.com/filecoin-project/go-data-transfer/pull/49))
+  - Use extracted generic pubsub (#48) ([filecoin-project/go-data-transfer#48](https://github.com/filecoin-project/go-data-transfer/pull/48))
+  - Refactor & Cleanup In Preparation For Added Complexity (#47) ([filecoin-project/go-data-transfer#47](https://github.com/filecoin-project/go-data-transfer/pull/47))
+  - feat(graphsync): complete notifications for responder (#46) ([filecoin-project/go-data-transfer#46](https://github.com/filecoin-project/go-data-transfer/pull/46))
+  - Update graphsync ([filecoin-project/go-data-transfer#45](https://github.com/filecoin-project/go-data-transfer/pull/45))
+  - docs(docs): remove outdated docs
+  - docs(README): clean up README
+  - docs(license): add license + contrib
+  - ci(circle): add config
+  - build(datatransfer): add go.mod
+  - build(cbor-gen): add tools for cbor-gen-for .
+  - fix links in datatransfer README (#11) ([filecoin-project/go-data-transfer#11](https://github.com/filecoin-project/go-data-transfer/pull/11))
+  - feat(shared): add shared tools and types (#9) ([filecoin-project/go-data-transfer#9](https://github.com/filecoin-project/go-data-transfer/pull/9))
+  - Feat/datatransfer readme, contributing, design doc (rename)
+  - refactor(datatransfer): move to local module
+  - feat(datatransfer): switch to graphsync implementation
+  - Don't respond with error in gsReqRcdHook when we can't find the datatransfer extension. (#754) ([filecoin-project/go-data-transfer#754](https://github.com/filecoin-project/go-data-transfer/pull/754))
+  - Feat/dt subscribe, file Xfer round trip (#720) ([filecoin-project/go-data-transfer#720](https://github.com/filecoin-project/go-data-transfer/pull/720))
+  - Feat/dt gs pullrequests (#693) ([filecoin-project/go-data-transfer#693](https://github.com/filecoin-project/go-data-transfer/pull/693))
+  - DTM sends data over graphsync for validated push requests (#665) ([filecoin-project/go-data-transfer#665](https://github.com/filecoin-project/go-data-transfer/pull/665))
+  - Techdebt/dt split graphsync impl receiver (#651) ([filecoin-project/go-data-transfer#651](https://github.com/filecoin-project/go-data-transfer/pull/651))
+  - Feat/dt initiator cleanup (#645) ([filecoin-project/go-data-transfer#645](https://github.com/filecoin-project/go-data-transfer/pull/645))
+  - Feat/dt graphsync pullreqs (#627) ([filecoin-project/go-data-transfer#627](https://github.com/filecoin-project/go-data-transfer/pull/627))
+  - fix(datatransfer): fix tests
+  - Graphsync response is scheduled when a valid push request is received (#625) ([filecoin-project/go-data-transfer#625](https://github.com/filecoin-project/go-data-transfer/pull/625))
+  - responses alert subscribers when request is not accepted (#607) ([filecoin-project/go-data-transfer#607](https://github.com/filecoin-project/go-data-transfer/pull/607))
+  - feat(datatransfer): milestone 2 infrastructure
+  - other tests passing
+  - send data transfer response
+  - a better reflection
+  - remove unused fmt import in graphsync_test
+  - cleanup for PR
+  - tests passing
+  - Initiate push and pull requests (#536) ([filecoin-project/go-data-transfer#536](https://github.com/filecoin-project/go-data-transfer/pull/536))
+  - Fix tests
+  - Respond to PR comments: * Make DataTransferRequest/Response be returned in from Net * Regenerate cbor_gen and fix the generator caller so it works better * Please the linters
+  - Cleanup for PR, clarifying and additional comments
+  - Some cleanup for PR
+  - all message tests passing, some others in datatransfer
+  - WIP trying out some stuff * Embed request/response in message so all the interfaces work AND the CBOR unmarshaling works: this is more like the spec anyway * get rid of pb stuff
+  - * Bring cbor-gen stuff into datatransfer package * make transferRequest private struct * add transferResponse + funcs * Rename VoucherID to VoucherType * more tests passing
+  - WIP using CBOR encoding for dataxfermsg
+  - feat(datatransfer): setup implementation path
+  - Duplicate comment ([filecoin-project/go-data-transfer#619](https://github.com/filecoin-project/go-data-transfer/pull/619))
+  - fix typo ([filecoin-project/go-data-transfer#621](https://github.com/filecoin-project/go-data-transfer/pull/621))
+  - fix types typo
+  - refactor(datatransfer): implement style fixes
+  - refactor(deals): move type instantiation to modules
+  - refactor(datatransfer): xerrors, cbor-gen, tweaks
+  - feat(datatransfer): make dag service dt async
+  - refactor(datatransfer): add comments, renames
+  - feat(datatransfer): integration w/ simple merkledag
+
+### Contributors
+
+| Contributor | Commits | Lines ± | Files Changed |
+|-------------|---------|---------|---------------|
+| Shannon Wells | 12 | +4337/-3455 | 53 |
+| hannahhoward | 20 | +5090/-1692 | 99 |
+| shannonwells | 13 | +1720/-983 | 65 |
+| Hannah Howard | 6 | +1393/-1262 | 45 |
+| wanghui | 2 | +4/-4 | 2 |
+| 郭光华 | 1 | +0/-1 | 1 |
+
+# go-data-transfer 0.2.1
+
+Bug fix release -- critical nil check
+
+### Changelog
+
+- github.com/filecoin-project/go-data-transfer:
+  - chore(deps): update graphsync
+- github.com/ipfs/go-graphsync (v0.0.6-0.20200428204348-97a8cf76a482 -> v0.0.6-0.20200504202014-9d5f2c26a103):
+  - fix(responsemanager): add nil check (#67) ([ipfs/go-graphsync#67](https://github.com/ipfs/go-graphsync/pull/67))
+  - Add autocomment configuration
+
+### Contributors
+
+| Contributor | Commits | Lines ± | Files Changed |
+|-------------|---------|---------|---------------|
+| Hector Sanjuan | 1 | +68/-0 | 1 |
+| hannahhoward | 1 | +3/-3 | 2 |
+| Hannah Howard | 1 | +4/-0 | 1 |
+
+# go-data-transfer 0.3.0
+
+Additional refactors to refactors to registry
+
+### Changelog 
+- github.com/filecoin-project/go-data-transfer:
+  - feat(graphsyncimpl): fix open/close events (#52) ([filecoin-project/go-data-transfer#52](https://github.com/filecoin-project/go-data-transfer/pull/52))
+  - chore(deps): update graphsync ([filecoin-project/go-data-transfer#51](https://github.com/filecoin-project/go-data-transfer/pull/51))
+  - Refactor registry and encoding (#50) ([filecoin-project/go-data-transfer#50](https://github.com/filecoin-project/go-data-transfer/pull/50))
+
+### Contributors
+
+| Contributor | Commits | Lines ± | Files Changed |
+|-------------|---------|---------|---------------|
+| Hannah Howard | 2 | +993/-496 | 30 |
+
+# go-data-transfer 0.4.0
+
+Major rewrite of library -- transports, persisted state, revalidators, etc. To support retrieval
+
+### Changelog
+
+- github.com/filecoin-project/go-data-transfer:
+  - The new data transfer (#55) ([filecoin-project/go-data-transfer#55](https://github.com/filecoin-project/go-data-transfer/pull/55))
+  - Actually track progress for send/receive (#53) ([filecoin-project/go-data-transfer#53](https://github.com/filecoin-project/go-data-transfer/pull/53))
+- github.com/ipfs/go-graphsync (v0.0.6-0.20200504202014-9d5f2c26a103 -> v0.0.6-0.20200708073926-caa872f68b2c):
+  - All changes to date including pause requests & start paused, along with new adds for cleanups and checking of execution (#75) ([ipfs/go-graphsync#75](https://github.com/ipfs/go-graphsync/pull/75))
+  - More fine grained response controls (#71) ([ipfs/go-graphsync#71](https://github.com/ipfs/go-graphsync/pull/71))
+  - Refactor request execution and use IPLD SkipMe functionality for proper partial results on a request (#70) ([ipfs/go-graphsync#70](https://github.com/ipfs/go-graphsync/pull/70))
+  - feat(graphsync): implement do-no-send-cids extension (#69) ([ipfs/go-graphsync#69](https://github.com/ipfs/go-graphsync/pull/69))
+  - Incoming Block Hooks (#68) ([ipfs/go-graphsync#68](https://github.com/ipfs/go-graphsync/pull/68))
+
+### Contributors
+
+| Contributor | Commits | Lines ± | Files Changed |
+|-------------|---------|---------|---------------|
+| Hannah Howard | 7 | +12381/-4583 | 133 |
+
+# go-data-transfer 0.5.0
+
+Additional changes to support implementation of retrieval on top of go-data-transfer
+
+### Changelog
+
+- github.com/filecoin-project/go-data-transfer:
+  - Minor fixes for retrieval on data transfer (#56) ([filecoin-project/go-data-transfer#56](https://github.com/filecoin-project/go-data-transfer/pull/56))
+- github.com/ipfs/go-graphsync (v0.0.6-0.20200708073926-caa872f68b2c -> v0.0.6-0.20200715204712-ef06b3d32e83):
+  - feat(requestmanager): run response hooks on completed requests (#77) ([ipfs/go-graphsync#77](https://github.com/ipfs/go-graphsync/pull/77))
+  - Revert "add extensions on complete (#76)"
+  - add extensions on complete (#76) ([ipfs/go-graphsync#76](https://github.com/ipfs/go-graphsync/pull/76))
+
+### Contributors
+
+| Contributor | Commits | Lines ± | Files Changed |
+|-------------|---------|---------|---------------|
+| Hannah Howard | 3 | +515/-218 | 26 |
+| hannahhoward | 1 | +155/-270 | 9 |
+
+# go-data-transfer v0.5.1
+
+Support custom configruation of transports
+
+### Changelog
+
+- github.com/filecoin-project/go-data-transfer:
+  - Allow custom configuration of transports (#57) ([filecoin-project/go-data-transfer#57](https://github.com/filecoin-project/go-data-transfer/pull/57))
+- github.com/ipfs/go-graphsync (v0.0.6-0.20200715204712-ef06b3d32e83 -> v0.0.6-0.20200721211002-c376cbe14c0a):
+  - feat(persistenceoptions): add unregister ability
+
+### Contributors
+
+| Contributor | Commits | Lines ± | Files Changed |
+|-------------|---------|---------|---------------|
+| Hannah Howard | 1 | +1049/-751 | 35 |
+| hannahhoward | 1 | +113/-32 | 5 |
+
+# go-data-transfer 0.5.2
+
+Security fix release
+
+### Changelog
+
+- github.com/filecoin-project/go-data-transfer:
+  - fix(deps): update graphsync
+  - fix(message): add error check to FromNet (#59) ([filecoin-project/go-data-transfer#59](https://github.com/filecoin-project/go-data-transfer/pull/59))
+- github.com/ipfs/go-graphsync (v0.0.6-0.20200721211002-c376cbe14c0a -> v0.0.6-0.20200731020347-9ff2ade94aa4):
+  - feat(persistenceoptions): add unregister ability (#80) ([ipfs/go-graphsync#80](https://github.com/ipfs/go-graphsync/pull/80))
+  - fix(message): regen protobuf code (#79) ([ipfs/go-graphsync#79](https://github.com/ipfs/go-graphsync/pull/79))
+
+### Contributors
+
+| Contributor | Commits | Lines ± | Files Changed |
+|-------------|---------|---------|---------------|
+| Hannah Howard | 3 | +442/-302 | 7 |
+| hannahhoward | 1 | +3/-3 | 2 |
+
+### 🙌🏽 Want to contribute?
+
+Would you like to contribute to this repo and don’t know how? Here are a few places you can get started:
+
+- Check out the [Contributing Guidelines](https://github.com/filecoin-project/go-data-transfer/blob/master/CONTRIBUTING.md)
+- Look for issues with the `good-first-issue` label in [go-fil-markets](https://github.com/filecoin-project/go-data-transfer/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22e-good-first-issue%22+)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,8 @@ import (
         <single, empty line>
         [external packages]
         <single, empty line>
+        [other-filecoin-project packages]
+        <single, empty line>
         [go-data-transfer packages]
 )
 ```
@@ -55,9 +57,13 @@ import (
 	"github.com/ipfs/go-cid"
 	cborgen "github.com/whyrusleeping/cbor-gen"
 
-	"github.com/filecoin-project/go-data-transfer"
+        "github.com/filecoin-project/go-statemachine"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
 )
 ```
+
+You can run `script/fiximports` to put all your code in the desired format
 
 #### Comments
 Comments are a communication to other developers (including your future self) to help them understand and maintain code. Good comments describe the _intent_ of the code, without repeating the procedures directly.

--- a/channels/channel_state.go
+++ b/channels/channel_state.go
@@ -3,13 +3,14 @@ package channels
 import (
 	"bytes"
 
-	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagcbor"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	cbg "github.com/whyrusleeping/cbor-gen"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
 )
 
 // channelState is immutable channel data plus mutable state

--- a/channels/channels.go
+++ b/channels/channels.go
@@ -5,14 +5,16 @@ import (
 	"errors"
 	"time"
 
-	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-data-transfer/encoding"
-	"github.com/filecoin-project/go-statemachine/fsm"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipld/go-ipld-prime"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	cbg "github.com/whyrusleeping/cbor-gen"
+
+	"github.com/filecoin-project/go-statemachine/fsm"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-data-transfer/encoding"
 )
 
 type DecoderByTypeFunc func(identifier datatransfer.TypeIdentifier) (encoding.Decoder, bool)

--- a/channels/channels_fsm.go
+++ b/channels/channels_fsm.go
@@ -1,10 +1,12 @@
 package channels
 
 import (
-	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-statemachine/fsm"
 	logging "github.com/ipfs/go-log"
 	cbg "github.com/whyrusleeping/cbor-gen"
+
+	"github.com/filecoin-project/go-statemachine/fsm"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
 )
 
 var log = logging.Logger("data-transfer")

--- a/channels/channels_test.go
+++ b/channels/channels_test.go
@@ -6,15 +6,16 @@ import (
 	"testing"
 	"time"
 
-	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-data-transfer/channels"
-	"github.com/filecoin-project/go-data-transfer/encoding"
-	"github.com/filecoin-project/go-data-transfer/testutil"
 	"github.com/ipfs/go-datastore"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-data-transfer/channels"
+	"github.com/filecoin-project/go-data-transfer/encoding"
+	"github.com/filecoin-project/go-data-transfer/testutil"
 )
 
 func TestChannels(t *testing.T) {

--- a/channels/internalchannel.go
+++ b/channels/internalchannel.go
@@ -1,10 +1,11 @@
 package channels
 
 import (
-	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/ipfs/go-cid"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	cbg "github.com/whyrusleeping/cbor-gen"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
 )
 
 //go:generate cbor-gen-for internalChannelState encodedVoucher encodedVoucherResult

--- a/impl/environment.go
+++ b/impl/environment.go
@@ -1,8 +1,9 @@
 package impl
 
 import (
-	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/libp2p/go-libp2p-core/peer"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
 )
 
 type channelEnvironment struct {

--- a/impl/events.go
+++ b/impl/events.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 
-	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-data-transfer/encoding"
-	"github.com/filecoin-project/go-data-transfer/registry"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/peer"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-data-transfer/encoding"
+	"github.com/filecoin-project/go-data-transfer/registry"
 )
 
 func (m *manager) OnChannelOpened(chid datatransfer.ChannelID) error {

--- a/impl/impl.go
+++ b/impl/impl.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/hannahhoward/go-pubsub"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log"
@@ -13,14 +14,14 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/go-storedcounter"
+
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/go-data-transfer/channels"
 	"github.com/filecoin-project/go-data-transfer/encoding"
 	"github.com/filecoin-project/go-data-transfer/message"
 	"github.com/filecoin-project/go-data-transfer/network"
 	"github.com/filecoin-project/go-data-transfer/registry"
-	"github.com/filecoin-project/go-storedcounter"
-	"github.com/hannahhoward/go-pubsub"
 )
 
 var log = logging.Logger("dt-impl")

--- a/impl/initiating_test.go
+++ b/impl/initiating_test.go
@@ -8,18 +8,18 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	dss "github.com/ipfs/go-datastore/sync"
-
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-storedcounter"
 
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/go-data-transfer/channels"
 	. "github.com/filecoin-project/go-data-transfer/impl"
 	"github.com/filecoin-project/go-data-transfer/message"
 	"github.com/filecoin-project/go-data-transfer/testutil"
-	"github.com/filecoin-project/go-storedcounter"
 )
 
 func TestDataTransferInitiating(t *testing.T) {

--- a/impl/integration_test.go
+++ b/impl/integration_test.go
@@ -7,14 +7,6 @@ import (
 	"testing"
 	"time"
 
-	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-data-transfer/encoding"
-	. "github.com/filecoin-project/go-data-transfer/impl"
-	"github.com/filecoin-project/go-data-transfer/message"
-	"github.com/filecoin-project/go-data-transfer/network"
-	"github.com/filecoin-project/go-data-transfer/testutil"
-	tp "github.com/filecoin-project/go-data-transfer/transport/graphsync"
-	"github.com/filecoin-project/go-data-transfer/transport/graphsync/extension"
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
@@ -31,6 +23,15 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-data-transfer/encoding"
+	. "github.com/filecoin-project/go-data-transfer/impl"
+	"github.com/filecoin-project/go-data-transfer/message"
+	"github.com/filecoin-project/go-data-transfer/network"
+	"github.com/filecoin-project/go-data-transfer/testutil"
+	tp "github.com/filecoin-project/go-data-transfer/transport/graphsync"
+	"github.com/filecoin-project/go-data-transfer/transport/graphsync/extension"
 )
 
 func TestRoundTrip(t *testing.T) {

--- a/impl/responding_test.go
+++ b/impl/responding_test.go
@@ -15,11 +15,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-storedcounter"
+
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	. "github.com/filecoin-project/go-data-transfer/impl"
 	"github.com/filecoin-project/go-data-transfer/message"
 	"github.com/filecoin-project/go-data-transfer/testutil"
-	"github.com/filecoin-project/go-storedcounter"
 )
 
 func TestDataTransferResponding(t *testing.T) {

--- a/impl/utils.go
+++ b/impl/utils.go
@@ -3,13 +3,14 @@ package impl
 import (
 	"context"
 
-	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-data-transfer/message"
-	"github.com/filecoin-project/go-data-transfer/registry"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"golang.org/x/xerrors"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-data-transfer/message"
+	"github.com/filecoin-project/go-data-transfer/registry"
 )
 
 type statusList []datatransfer.Status

--- a/message.go
+++ b/message.go
@@ -3,10 +3,11 @@ package datatransfer
 import (
 	"io"
 
-	"github.com/filecoin-project/go-data-transfer/encoding"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	cborgen "github.com/whyrusleeping/cbor-gen"
+
+	"github.com/filecoin-project/go-data-transfer/encoding"
 )
 
 // Message is a message for the data transfer protocol

--- a/message/transfer_request.go
+++ b/message/transfer_request.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"io"
 
-	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-data-transfer/encoding"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagcbor"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-data-transfer/encoding"
 )
 
 //go:generate cbor-gen-for transferRequest

--- a/message/transfer_response.go
+++ b/message/transfer_response.go
@@ -3,10 +3,11 @@ package message
 import (
 	"io"
 
-	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-data-transfer/encoding"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-data-transfer/encoding"
 )
 
 //go:generate cbor-gen-for transferResponse

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -3,9 +3,10 @@ package registry
 import (
 	"sync"
 
+	"golang.org/x/xerrors"
+
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/go-data-transfer/encoding"
-	"golang.org/x/xerrors"
 )
 
 // Processor is an interface that processes a certain type of encodable objects

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -3,9 +3,10 @@ package registry_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/filecoin-project/go-data-transfer/registry"
 	"github.com/filecoin-project/go-data-transfer/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRegistry(t *testing.T) {

--- a/scripts/fiximports
+++ b/scripts/fiximports
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+find . -type f -name \*.go -not -name \*_cbor_gen.go | xargs -I '{}' sed -i.bak -e '/import (/ {
+  :1
+  $!N
+  s/\n\n/\'$'\n''/
+  /)/!b1
+}' '{}'
+git clean -fd
+find . -type f -name \*.go  -not -name \*_cbor_gen.go | xargs -I '{}' goimports -w -local "github.com/filecoin-project" '{}'
+find . -type f -name \*.go  -not -name \*_cbor_gen.go | xargs -I '{}' goimports -w -local "github.com/filecoin-project/go-data-transfer" '{}'
+

--- a/scripts/mkreleaselog
+++ b/scripts/mkreleaselog
@@ -1,0 +1,246 @@
+#!/bin/zsh
+
+# Note: This script is a modified version of the mkreleaselog script used by
+# the go-ipfs team.
+#
+# Usage: ./mkreleaselog v0.25.0 v0.26.0 > /tmp/release.log
+
+set -euo pipefail
+export GO111MODULE=on
+export GOPATH="$(go env GOPATH)"
+
+alias jq="jq --unbuffered"
+
+REPO_SUFFIXES_TO_STRIP=(
+    "/v2"
+    "/v3"
+    "/v4"
+    "/v5"
+    "/v6"
+)
+
+AUTHORS=(
+    # orgs
+    filecoin-project/go-data-transfer
+    ipfs/go-graphsync
+
+    # Authors of personal repos used by filecoin-ffi that should be mentioned in the
+    # release notes.
+    xlab
+    hannahhoward
+)
+
+[[ -n "${REPO_FILTER+x}" ]] || REPO_FILTER="github.com/(${$(printf "|%s" "${AUTHORS[@]}"):1})"
+echo $REPO_FILTER
+[[ -n "${IGNORED_FILES+x}" ]] || IGNORED_FILES='^\(\.gx\|package\.json\|\.travis\.yml\|go.mod\|go\.sum|\.github|\.circleci\)$'
+
+NL=$'\n'
+
+msg() {
+    echo "$*" >&2
+}
+
+statlog() {
+    rpath="$GOPATH/src/$1"
+    for s in $REPO_SUFFIXES_TO_STRIP; do
+        rpath=${rpath%$s}
+    done
+
+    start="${2:-}"
+    end="${3:-HEAD}"
+
+    git -C "$rpath" log --shortstat --no-merges --pretty="tformat:%H%n%aN%n%aE" "$start..$end" | while
+        read hash
+        read name
+        read email
+        read _ # empty line
+        read changes
+    do
+        changed=0
+        insertions=0
+        deletions=0
+        while read count event; do
+            if [[ "$event" =~ ^file ]]; then
+                changed=$count
+            elif [[ "$event" =~ ^insertion ]]; then
+                insertions=$count
+            elif [[ "$event" =~ ^deletion ]]; then
+                deletions=$count
+            else
+                echo "unknown event $event" >&2
+                exit 1
+            fi
+        done<<<"${changes//,/$NL}"
+
+        jq -n \
+           --arg "hash" "$hash" \
+           --arg "name" "$name" \
+           --arg "email" "$email" \
+           --argjson "changed" "$changed" \
+           --argjson "insertions" "$insertions" \
+           --argjson "deletions" "$deletions" \
+           '{Commit: $hash, Author: $name, Email: $email, Files: $changed, Insertions: $insertions, Deletions: $deletions}'
+    done
+}
+
+# Returns a stream of deps changed between $1 and $2.
+dep_changes() {
+    {
+        <"$1"
+        <"$2"
+    } | jq -s 'JOIN(INDEX(.[0][]; .Path); .[1][]; .Path; {Path: .[0].Path, Old: (.[1] | del(.Path)), New: (.[0] | del(.Path))}) | select(.New.Version != .Old.Version)'
+}
+
+# resolve_commits resolves a git ref for each version.
+resolve_commits() {
+    jq '. + {Ref: (.Version|capture("^((?<ref1>.*)\\+incompatible|v.*-(0\\.)?[0-9]{14}-(?<ref2>[a-f0-9]{12})|(?<ref3>v.*))$") | .ref1 // .ref2 // .ref3)}'
+}
+
+pr_link() {
+    local repo="$1"
+    local prnum="$2"
+    local ghname="${repo##github.com/}"
+    printf -- "[%s#%s](https://%s/pull/%s)" "$ghname" "$prnum" "$repo" "$prnum"
+}
+
+# Generate a release log for a range of commits in a single repo.
+release_log() {
+    setopt local_options BASH_REMATCH
+
+    local repo="$1"
+    local start="$2"
+    local end="${3:-HEAD}"
+    local dir="$GOPATH/src/$repo"
+
+    local commit pr
+    git -C "$dir" log \
+        --format='tformat:%H %s' \
+        --first-parent \
+        "$start..$end" |
+        while read commit subject; do
+            # Skip gx-only PRs.
+            git -C "$dir" diff-tree --no-commit-id --name-only "$commit^" "$commit" |
+                grep -v "${IGNORED_FILES}" >/dev/null || continue
+
+            if [[ "$subject" =~ '^Merge pull request #([0-9]+) from' ]]; then
+                local prnum="${BASH_REMATCH[2]}"
+                local desc="$(git -C "$dir" show --summary --format='tformat:%b' "$commit" | head -1)"
+                printf -- "- %s (%s)\n" "$desc" "$(pr_link "$repo" "$prnum")"
+            elif [[ "$subject" =~ '\(#([0-9]+)\)$' ]]; then
+                local prnum="${BASH_REMATCH[2]}"
+                printf -- "- %s (%s)\n" "$subject" "$(pr_link "$repo" "$prnum")"
+            else
+                printf -- "- %s\n" "$subject"
+            fi
+        done
+}
+
+indent() {
+    sed -e 's/^/  /'
+}
+
+mod_deps() {
+    go list -json -m all | jq 'select(.Version != null)'
+}
+
+ensure() {
+    local repo="$1"
+    for s in $REPO_SUFFIXES_TO_STRIP; do
+        repo=${repo%$s}
+    done
+
+    local commit="$2"
+
+    local rpath="$GOPATH/src/$repo"
+    if [[ ! -d "$rpath" ]]; then
+        msg "Cloning $repo..."
+        git clone "http://$repo" "$rpath" >&2
+    fi
+
+    if ! git -C "$rpath" rev-parse --verify "$commit" >/dev/null; then
+        msg "Fetching $repo..."
+        git -C "$rpath" fetch --all >&2
+    fi
+
+    git -C "$rpath" rev-parse --verify "$commit" >/dev/null || return 1
+}
+
+statsummary() {
+    jq -s 'group_by(.Author)[] | {Author: .[0].Author, Commits: (. | length), Insertions: (map(.Insertions) | add), Deletions: (map(.Deletions) | add), Files: (map(.Files) | add)}' |
+        jq '. + {Lines: (.Deletions + .Insertions)}'
+}
+
+recursive_release_log() {
+    local start="${1:-$(git tag -l | sort -V | grep -v -- '-rc' | grep 'v'| tail -n1)}"
+    local end="${2:-$(git rev-parse HEAD)}"
+    local repo_root="$(git rev-parse --show-toplevel)"
+    local package="$(cd "$repo_root" && go list -m)"
+
+    if ! [[ "${GOPATH}/${package}" != "${repo_root}" ]]; then
+        echo "This script requires the target package and all dependencies to live in a GOPATH."
+        return 1
+    fi
+
+    (
+        local result=0
+        local workspace="$(mktemp -d)"
+        trap "$(printf 'rm -rf "%q"' "$workspace")" INT TERM EXIT
+        cd "$workspace"
+
+        echo "Computing old deps..." >&2
+        git -C "$repo_root" show "$start:go.mod" >go.mod
+        sed "s/^replace.*//g" go.mod > go.mod.new
+        mv go.mod.new go.mod
+        mod_deps | resolve_commits | jq -s > old_deps.json
+
+        echo "Computing new deps..." >&2
+        git -C "$repo_root" show "$end:go.mod" >go.mod
+        sed "s/^replace.*//g" go.mod > go.mod.new
+        mv go.mod.new go.mod
+        mod_deps | resolve_commits | jq -s > new_deps.json
+
+        rm -f go.mod go.sum
+
+        printf -- "Generating Changelog for %s %s..%s\n" "$package" "$start" "$end" >&2
+
+        printf -- "- %s:\n" "$package"
+        release_log "$package" "$start" "$end" | indent
+
+        statlog "$package" "$start" "$end" > statlog.json
+
+        dep_changes old_deps.json new_deps.json |
+            jq --arg filter "$REPO_FILTER" 'select(.Path | match($filter))' |
+            # Compute changelogs
+            jq -r '"\(.Path) \(.New.Version) \(.New.Ref) \(.Old.Version) \(.Old.Ref // "")"' |
+            while read repo new new_ref old old_ref; do
+                for s in $REPO_SUFFIXES_TO_STRIP; do
+                    repo=${repo%$s}
+                done
+
+                if ! ensure "$repo" "$new_ref"; then
+                    result=1
+                    local changelog="failed to fetch repo"
+                else
+                    statlog "$repo" "$old_ref" "$new_ref" >> statlog.json
+                    local changelog="$(release_log "$repo" "$old_ref" "$new_ref")"
+                fi
+                if [[ -n "$changelog" ]]; then
+                    printf -- "- %s (%s -> %s):\n" "$repo" "$old" "$new"
+                    echo "$changelog" | indent
+                fi
+            done
+
+        echo
+        echo "Contributors"
+        echo
+
+        echo "| Contributor | Commits | Lines ± | Files Changed |"
+        echo "|-------------|---------|---------|---------------|"
+        statsummary <statlog.json |
+            jq -s 'sort_by(.Lines) | reverse | .[]' |
+            jq -r '"| \(.Author) | \(.Commits) | +\(.Insertions)/-\(.Deletions) | \(.Files) |"'
+        return "$status"
+    )
+}
+
+recursive_release_log "$@"

--- a/testutil/fakegraphsync.go
+++ b/testutil/fakegraphsync.go
@@ -8,9 +8,6 @@ import (
 	"sync"
 	"testing"
 
-	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-data-transfer/message"
-	"github.com/filecoin-project/go-data-transfer/transport/graphsync/extension"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipld/go-ipld-prime"
@@ -18,6 +15,10 @@ import (
 	"github.com/ipld/go-ipld-prime/traversal"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-data-transfer/message"
+	"github.com/filecoin-project/go-data-transfer/transport/graphsync/extension"
 )
 
 func matchDtMessage(t *testing.T, extensions []graphsync.ExtensionData) datatransfer.Message {

--- a/testutil/faketransport.go
+++ b/testutil/faketransport.go
@@ -3,9 +3,10 @@ package testutil
 import (
 	"context"
 
-	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/peer"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
 )
 
 // OpenedChannel records a call to open a channel

--- a/testutil/gstestdata.go
+++ b/testutil/gstestdata.go
@@ -11,10 +11,6 @@ import (
 	"runtime"
 	"testing"
 
-	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-data-transfer/network"
-	gstransport "github.com/filecoin-project/go-data-transfer/transport/graphsync"
-	"github.com/filecoin-project/go-storedcounter"
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
@@ -40,6 +36,12 @@ import (
 	"github.com/libp2p/go-libp2p-core/host"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-storedcounter"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-data-transfer/network"
+	gstransport "github.com/filecoin-project/go-data-transfer/transport/graphsync"
 )
 
 var allSelector ipld.Node

--- a/testutil/message.go
+++ b/testutil/message.go
@@ -3,11 +3,12 @@ package testutil
 import (
 	"testing"
 
-	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-data-transfer/message"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 	"github.com/stretchr/testify/require"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-data-transfer/message"
 )
 
 // NewDTRequest makes a new DT Request message

--- a/testutil/testnet.go
+++ b/testutil/testnet.go
@@ -3,9 +3,10 @@ package testutil
 import (
 	"context"
 
+	"github.com/libp2p/go-libp2p-core/peer"
+
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/go-data-transfer/network"
-	"github.com/libp2p/go-libp2p-core/peer"
 )
 
 // FakeSentMessage is a recording of a message sent on the FakeNetwork

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"testing"
 
-	datatransfer "github.com/filecoin-project/go-data-transfer"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
@@ -15,6 +14,8 @@ import (
 	"github.com/jbenet/go-random"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
 )
 
 var blockGenerator = blocksutil.NewBlockGenerator()

--- a/transport/graphsync/extension/gsextension.go
+++ b/transport/graphsync/extension/gsextension.go
@@ -3,9 +3,10 @@ package extension
 import (
 	"bytes"
 
+	"github.com/ipfs/go-graphsync"
+
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/go-data-transfer/message"
-	"github.com/ipfs/go-graphsync"
 )
 
 const (

--- a/transport/graphsync/graphsync.go
+++ b/transport/graphsync/graphsync.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"sync"
 
-	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-data-transfer/transport/graphsync/extension"
 	"github.com/ipfs/go-graphsync"
 	ipld "github.com/ipld/go-ipld-prime"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/prometheus/common/log"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-data-transfer/transport/graphsync/extension"
 )
 
 var errContextCancelled = errors.New("context cancelled")

--- a/transport/graphsync/graphsync_test.go
+++ b/transport/graphsync/graphsync_test.go
@@ -9,16 +9,17 @@ import (
 	"testing"
 	"time"
 
-	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-data-transfer/message"
-	"github.com/filecoin-project/go-data-transfer/testutil"
-	. "github.com/filecoin-project/go-data-transfer/transport/graphsync"
-	"github.com/filecoin-project/go-data-transfer/transport/graphsync/extension"
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-data-transfer/message"
+	"github.com/filecoin-project/go-data-transfer/testutil"
+	. "github.com/filecoin-project/go-data-transfer/transport/graphsync"
+	"github.com/filecoin-project/go-data-transfer/transport/graphsync/extension"
 )
 
 func TestManager(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -3,10 +3,11 @@ package datatransfer
 import (
 	"fmt"
 
-	"github.com/filecoin-project/go-data-transfer/encoding"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/peer"
+
+	"github.com/filecoin-project/go-data-transfer/encoding"
 )
 
 type errorString string


### PR DESCRIPTION
# Goals

Tidy up go-data-transfer releases by adding several infrastructure pieces imported from go-fil-markets

# Implementation

- copy over imports and release scripts
- add cbor-gen-check and imports-check to CI
- generate a changelog
- run imports cleanup