### PR TITLE
Ensure valid messages are returned from FromNet()

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -150,8 +150,13 @@ func FromNet(r io.Reader) (datatransfer.Message, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if (tresp.IsRequest() && tresp.Request == nil) || (!tresp.IsRequest() && tresp.Response == nil) {
+		return nil, xerrors.Errorf("invalid/malformed message")
+	}
+
 	if tresp.IsRequest() {
 		return tresp.Request, nil
 	}
-	return tresp.Response, err
+	return tresp.Response, nil
 }

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -298,6 +298,20 @@ func TestToNetFromNetEquivalency(t *testing.T) {
 	require.Equal(t, deserializedRequest.IsRequest(), request.IsRequest())
 }
 
+func TestFromNetMessageValidation(t *testing.T) {
+	// craft request message with nil request struct
+	buf := []byte{0x83, 0xf5, 0xf6, 0xf6}
+	msg, err := FromNet(bytes.NewBuffer(buf))
+	assert.Error(t, err)
+	assert.Nil(t, msg)
+
+	// craft response message with nil response struct
+	buf = []byte{0x83, 0xf4, 0xf6, 0xf6}
+	msg, err = FromNet(bytes.NewBuffer(buf))
+	assert.Error(t, err)
+	assert.Nil(t, msg)
+}
+
 func NewTestTransferRequest() (datatransfer.Request, error) {
 	bcid := testutil.GenerateCids(1)[0]
 	selector := builder.NewSelectorSpecBuilder(basicnode.Style.Any).Matcher().Node()


### PR DESCRIPTION
## Summary
Fix cases where we could be returning a nil `datatransfer.Message` when deserializing malformed payloads.

Resolves #73