### PR TITLE
Cleanup errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -24,3 +24,12 @@ const ErrPause = errorType("pause channel")
 // ErrResume is a special error that the RequestReceived / ResponseReceived hooks can
 // use to resume the channel
 const ErrResume = errorType("resume channel")
+
+// ErrIncomplete indicates a channel did not finish transferring data successfully
+const ErrIncomplete = errorType("incomplete response")
+
+// ErrRejected indicates a request was not accepted
+const ErrRejected = errorType("response rejected")
+
+// ErrUnsupported indicates an operation is not supported by the transport protocol
+const ErrUnsupported = errorType("unsupported")

--- a/impl/impl.go
+++ b/impl/impl.go
@@ -231,7 +231,7 @@ func (m *manager) PauseDataTransferChannel(ctx context.Context, chid datatransfe
 
 	pausable, ok := m.transport.(datatransfer.PauseableTransport)
 	if !ok {
-		return errors.New("unsupported")
+		return datatransfer.ErrUnsupported
 	}
 
 	err := pausable.PauseChannel(ctx, chid)
@@ -252,7 +252,7 @@ func (m *manager) PauseDataTransferChannel(ctx context.Context, chid datatransfe
 func (m *manager) ResumeDataTransferChannel(ctx context.Context, chid datatransfer.ChannelID) error {
 	pausable, ok := m.transport.(datatransfer.PauseableTransport)
 	if !ok {
-		return errors.New("unsupported")
+		return datatransfer.ErrUnsupported
 	}
 
 	err := pausable.ResumeChannel(ctx, m.resumeMessage(chid), chid)

--- a/impl/integration_test.go
+++ b/impl/integration_test.go
@@ -593,21 +593,21 @@ type retrievalRevalidator struct {
 	finalVoucher       datatransfer.VoucherResult
 }
 
-func (r *retrievalRevalidator) OnPullDataSent(chid datatransfer.ChannelID, additionalBytesSent uint64) (datatransfer.VoucherResult, error) {
+func (r *retrievalRevalidator) OnPullDataSent(chid datatransfer.ChannelID, additionalBytesSent uint64) (bool, datatransfer.VoucherResult, error) {
 	r.dataSoFar += additionalBytesSent
 	if r.providerPausePoint < len(r.pausePoints) &&
 		r.dataSoFar >= r.pausePoints[r.providerPausePoint] {
 		r.providerPausePoint++
-		return testutil.NewFakeDTType(), datatransfer.ErrPause
+		return true, testutil.NewFakeDTType(), datatransfer.ErrPause
 	}
-	return nil, nil
+	return true, nil, nil
 }
 
-func (r *retrievalRevalidator) OnPushDataReceived(chid datatransfer.ChannelID, additionalBytesReceived uint64) (datatransfer.VoucherResult, error) {
-	return nil, nil
+func (r *retrievalRevalidator) OnPushDataReceived(chid datatransfer.ChannelID, additionalBytesReceived uint64) (bool, datatransfer.VoucherResult, error) {
+	return false, nil, nil
 }
-func (r *retrievalRevalidator) OnComplete(chid datatransfer.ChannelID) (datatransfer.VoucherResult, error) {
-	return r.finalVoucher, datatransfer.ErrPause
+func (r *retrievalRevalidator) OnComplete(chid datatransfer.ChannelID) (bool, datatransfer.VoucherResult, error) {
+	return true, r.finalVoucher, datatransfer.ErrPause
 }
 
 func TestSimulatedRetrievalFlow(t *testing.T) {

--- a/impl/responding_test.go
+++ b/impl/responding_test.go
@@ -482,6 +482,27 @@ func TestDataTransferResponding(t *testing.T) {
 				require.False(t, response.IsPaused())
 			},
 		},
+		"validated, incomplete response": {
+			expectedEvents: []datatransfer.EventCode{
+				datatransfer.Open,
+				datatransfer.NewVoucherResult,
+				datatransfer.Accept,
+				datatransfer.Error,
+				datatransfer.CleanupComplete,
+			},
+			configureValidator: func(sv *testutil.StubbedValidator) {
+				sv.ExpectSuccessPull()
+				sv.StubResult(testutil.NewFakeDTType())
+			},
+			configureRevalidator: func(srv *testutil.StubbedRevalidator) {
+			},
+			verify: func(t *testing.T, h *receiverHarness) {
+				_, err := h.transport.EventHandler.OnRequestReceived(channelID(h.id, h.peers), h.pullRequest)
+				require.NoError(t, err)
+				err = h.transport.EventHandler.OnChannelCompleted(channelID(h.id, h.peers), false)
+				require.NoError(t, err)
+			},
+		},
 		"new push request, customized transport": {
 			expectedEvents: []datatransfer.EventCode{datatransfer.Open, datatransfer.NewVoucherResult, datatransfer.Accept},
 			configureValidator: func(sv *testutil.StubbedValidator) {

--- a/manager.go
+++ b/manager.go
@@ -31,20 +31,30 @@ type Revalidator interface {
 	// Revalidate revalidates a request with a new voucher
 	Revalidate(channelID ChannelID, voucher Voucher) (VoucherResult, error)
 	// OnPullDataSent is called on the responder side when more bytes are sent
-	// for a given pull request. It should return a VoucherResult + ErrPause to
+	// for a given pull request. The first value indicates whether the request was
+	// recognized by this revalidator and should be considered 'handled'. If true,
+	// the remaining two values are interpreted. If 'false' the request is passed on
+	// to the next revalidators.
+	// It should return a VoucherResult + ErrPause to
 	// request revalidation or nil to continue uninterrupted,
-	// other errors will terminate the request
-	OnPullDataSent(chid ChannelID, additionalBytesSent uint64) (VoucherResult, error)
+	// other errors will terminate the request.
+	OnPullDataSent(chid ChannelID, additionalBytesSent uint64) (bool, VoucherResult, error)
 	// OnPushDataReceived is called on the responder side when more bytes are received
-	// for a given push request.  It should return a VoucherResult + ErrPause to
+	// for a given push request. The first value indicates whether the request was
+	// recognized by this revalidator and should be considered 'handled'. If true,
+	// the remaining two values are interpreted. If 'false' the request is passed on
+	// to the next revalidators. It should return a VoucherResult + ErrPause to
 	// request revalidation or nil to continue uninterrupted,
 	// other errors will terminate the request
-	OnPushDataReceived(chid ChannelID, additionalBytesReceived uint64) (VoucherResult, error)
+	OnPushDataReceived(chid ChannelID, additionalBytesReceived uint64) (bool, VoucherResult, error)
 	// OnComplete is called to make a final request for revalidation -- often for the
-	// purpose of settlement.
+	// purpose of settlement. The first value indicates whether the request was
+	// recognized by this revalidator and should be considered 'handled'. If true,
+	// the remaining two values are interpreted. If 'false' the request is passed on
+	// to the next revalidators.
 	// if VoucherResult is non nil, the request will enter a settlement phase awaiting
 	// a final update
-	OnComplete(chid ChannelID) (VoucherResult, error)
+	OnComplete(chid ChannelID) (bool, VoucherResult, error)
 }
 
 // TransportConfigurer provides a mechanism to provide transport specific configuration for a given voucher type

--- a/testutil/stubbedvalidator.go
+++ b/testutil/stubbedvalidator.go
@@ -165,21 +165,21 @@ func NewStubbedRevalidator() *StubbedRevalidator {
 }
 
 // OnPullDataSent returns a stubbed result for checking when pull data is sent
-func (srv *StubbedRevalidator) OnPullDataSent(chid datatransfer.ChannelID, additionalBytesSent uint64) (datatransfer.VoucherResult, error) {
+func (srv *StubbedRevalidator) OnPullDataSent(chid datatransfer.ChannelID, additionalBytesSent uint64) (bool, datatransfer.VoucherResult, error) {
 	srv.didPullCheck = true
-	return srv.revalidationResult, srv.pullCheckError
+	return srv.expectPullCheck, srv.revalidationResult, srv.pullCheckError
 }
 
 // OnPushDataReceived returns a stubbed result for checking when push data is received
-func (srv *StubbedRevalidator) OnPushDataReceived(chid datatransfer.ChannelID, additionalBytesReceived uint64) (datatransfer.VoucherResult, error) {
+func (srv *StubbedRevalidator) OnPushDataReceived(chid datatransfer.ChannelID, additionalBytesReceived uint64) (bool, datatransfer.VoucherResult, error) {
 	srv.didPushCheck = true
-	return srv.revalidationResult, srv.pushCheckError
+	return srv.expectPushCheck, srv.revalidationResult, srv.pushCheckError
 }
 
 // OnComplete returns a stubbed result for checking when the requests completes
-func (srv *StubbedRevalidator) OnComplete(chid datatransfer.ChannelID) (datatransfer.VoucherResult, error) {
+func (srv *StubbedRevalidator) OnComplete(chid datatransfer.ChannelID) (bool, datatransfer.VoucherResult, error) {
 	srv.didComplete = true
-	return srv.revalidationResult, srv.completeError
+	return srv.expectComplete, srv.revalidationResult, srv.completeError
 }
 
 // Revalidate returns a stubbed result for revalidating a request


### PR DESCRIPTION
# Goals

- Use more standardized errors
- Insure 1 error per failing request (don't error twice on a response rejection)

# Implementation

- add some sentinel errors
- in OnRequestCompleted, check if the request is already failing before dispatching an incomplete error
- add a test to verify this behavior
