### PR TITLE
Handle network errors/stalls

### DIFF
--- a/channels/channels_fsm.go
+++ b/channels/channels_fsm.go
@@ -17,7 +17,10 @@ var log = logging.Logger("data-transfer")
 var ChannelEvents = fsm.Events{
 	fsm.Event(datatransfer.Open).FromAny().To(datatransfer.Requested),
 	fsm.Event(datatransfer.Accept).From(datatransfer.Requested).To(datatransfer.Ongoing),
-	fsm.Event(datatransfer.Restart).FromAny().To(datatransfer.Ongoing),
+	fsm.Event(datatransfer.Restart).FromAny().ToNoChange().Action(func(chst *internal.ChannelState) error {
+		chst.Message = ""
+		return nil
+	}),
 
 	fsm.Event(datatransfer.Cancel).FromAny().To(datatransfer.Cancelling),
 
@@ -46,7 +49,10 @@ var ChannelEvents = fsm.Events{
 		return nil
 	}),
 
-	fsm.Event(datatransfer.Disconnected).FromAny().To(datatransfer.PeerDisconnected),
+	fsm.Event(datatransfer.Disconnected).FromAny().ToNoChange().Action(func(chst *internal.ChannelState) error {
+		chst.Message = datatransfer.ErrDisconnected.Error()
+		return nil
+	}),
 
 	fsm.Event(datatransfer.Error).FromAny().To(datatransfer.Failing).Action(func(chst *internal.ChannelState, err error) error {
 		chst.Message = err.Error()

--- a/channels/channels_test.go
+++ b/channels/channels_test.go
@@ -303,7 +303,7 @@ func TestChannels(t *testing.T) {
 		err = channelList.Disconnected(chid)
 		require.NoError(t, err)
 		state = checkEvent(ctx, t, received, datatransfer.Disconnected)
-		require.Equal(t, datatransfer.PeerDisconnected, state.Status())
+		require.Equal(t, datatransfer.ErrDisconnected.Error(), state.Message())
 	})
 
 	t.Run("test self peer and other peer", func(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -33,3 +33,9 @@ const ErrRejected = errorType("response rejected")
 
 // ErrUnsupported indicates an operation is not supported by the transport protocol
 const ErrUnsupported = errorType("unsupported")
+
+// ErrDisconnected indicates the other peer may have hung up and you should try restarting the channel.
+const ErrDisconnected = errorType("other peer appears to have hung up. restart Channel")
+
+// ErrRemoved indicates the channel was inactive long enough that it was put in a permaneant error state
+const ErrRemoved = errorType("channel removed due to inactivity")

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/ipfs/go-blockservice v0.1.3
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-datastore v0.4.5
-	github.com/ipfs/go-graphsync v0.2.1
+	github.com/ipfs/go-graphsync v0.2.1-0.20201013053840-5d8ea8076a2c
 	github.com/ipfs/go-ipfs-blockstore v1.0.1
 	github.com/ipfs/go-ipfs-blocksutil v0.0.1
 	github.com/ipfs/go-ipfs-chunker v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/ipfs/go-ds-badger v0.0.5/go.mod h1:g5AuuCGmr7efyzQhLL8MzwqcauPojGPUaH
 github.com/ipfs/go-ds-badger v0.2.1/go.mod h1:Tx7l3aTph3FMFrRS838dcSJh+jjA7cX9DrGVwx/NOwE=
 github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIykR4L04tMOYc=
 github.com/ipfs/go-ds-leveldb v0.4.1/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1Ii2r79Hh9s=
-github.com/ipfs/go-graphsync v0.2.1 h1:MdehhqBSuTI2LARfKLkpYnt0mUrqHs/mtuDnESXHBfU=
-github.com/ipfs/go-graphsync v0.2.1/go.mod h1:gEBvJUNelzMkaRPJTpg/jaKN4AQW/7wDWu0K92D8o10=
+github.com/ipfs/go-graphsync v0.2.1-0.20201013053840-5d8ea8076a2c h1:De/AZGvRa3WMyw5zdMMhcvRcho46BVo+C0NRud+T4io=
+github.com/ipfs/go-graphsync v0.2.1-0.20201013053840-5d8ea8076a2c/go.mod h1:gEBvJUNelzMkaRPJTpg/jaKN4AQW/7wDWu0K92D8o10=
 github.com/ipfs/go-ipfs-blockstore v0.0.1/go.mod h1:d3WClOmRQKFnJ0Jz/jj/zmksX0ma1gROTlovZKBmN08=
 github.com/ipfs/go-ipfs-blockstore v0.1.0/go.mod h1:5aD0AvHPi7mZc6Ci1WCAhiBQu2IsfTduLl+422H6Rqw=
 github.com/ipfs/go-ipfs-blockstore v0.1.4 h1:2SGI6U1B44aODevza8Rde3+dY30Pb+lbcObe1LETxOQ=

--- a/impl/restart.go
+++ b/impl/restart.go
@@ -14,6 +14,7 @@ import (
 	"github.com/filecoin-project/go-data-transfer/message"
 )
 
+// ChannelDataTransferType identifies the type of a data transfer channel for the purposes of a restart
 type ChannelDataTransferType int
 
 const (
@@ -23,10 +24,10 @@ const (
 	// ManagerPeerCreatePush is the type of a channel wherein the manager peer created a Push Data Transfer
 	ManagerPeerCreatePush
 
-	// ManagerPeerCreatePush is the type of a channel wherein the manager peer received a Pull Data Transfer Request
+	// ManagerPeerReceivePull is the type of a channel wherein the manager peer received a Pull Data Transfer Request
 	ManagerPeerReceivePull
 
-	// ManagerPeerCreatePush is the type of a channel wherein the manager peer received a Push Data Transfer Request
+	// ManagerPeerReceivePush is the type of a channel wherein the manager peer received a Push Data Transfer Request
 	ManagerPeerReceivePush
 )
 

--- a/statuses.go
+++ b/statuses.go
@@ -58,9 +58,6 @@ const (
 
 	// ChannelNotFoundError means the searched for data transfer does not exist
 	ChannelNotFoundError
-
-	// PeerDisconnected means that we do NOT have a connection to the other peer
-	PeerDisconnected
 )
 
 // Statuses are human readable names for data transfer states

--- a/testutil/fakegraphsync.go
+++ b/testutil/fakegraphsync.go
@@ -110,6 +110,8 @@ type FakeGraphSync struct {
 	RequestUpdatedHook         graphsync.OnRequestUpdatedHook
 	IncomingResponseHook       graphsync.OnIncomingResponseHook
 	RequestorCancelledListener graphsync.OnRequestorCancelledListener
+	BlockSentListener          graphsync.OnBlockSentListener
+	NetworkErrorListener       graphsync.OnNetworkErrorListener
 }
 
 // NewFakeGraphSync returns a new fake graphsync implementation
@@ -349,6 +351,18 @@ func (fgs *FakeGraphSync) CancelResponse(p peer.ID, requestID graphsync.RequestI
 // RegisterRequestorCancelledListener adds a listener on the responder for requests cancelled by the requestor
 func (fgs *FakeGraphSync) RegisterRequestorCancelledListener(listener graphsync.OnRequestorCancelledListener) graphsync.UnregisterHookFunc {
 	fgs.RequestorCancelledListener = listener
+	return nil
+}
+
+// RegisterBlockSentListener adds a listener on the responder as blocks go out
+func (fgs *FakeGraphSync) RegisterBlockSentListener(listener graphsync.OnBlockSentListener) graphsync.UnregisterHookFunc {
+	fgs.BlockSentListener = listener
+	return nil
+}
+
+// RegisterNetworkErrorListener adds a listener on the responder as blocks go out
+func (fgs *FakeGraphSync) RegisterNetworkErrorListener(listener graphsync.OnNetworkErrorListener) graphsync.UnregisterHookFunc {
+	fgs.NetworkErrorListener = listener
 	return nil
 }
 

--- a/transport.go
+++ b/transport.go
@@ -51,6 +51,10 @@ type EventsHandler interface {
 	// OnRequestTimedOut is called when a request we opened (with the given channel Id) to receive data times out.
 	// Error returns are logged but otherwise have no effect
 	OnRequestTimedOut(ctx context.Context, chid ChannelID) error
+
+	// OnRequestDisconnected is called when a network error occurs in a graphsync request
+	// or we appear to stall while receiving data
+	OnRequestDisconnected(ctx context.Context, chid ChannelID) error
 }
 
 /*

--- a/transport/graphsync/graphsync_test.go
+++ b/transport/graphsync/graphsync_test.go
@@ -628,6 +628,16 @@ func TestManager(t *testing.T) {
 				assertDecodesToMessage(t, gsData.incomingRequestHookActions.SentExtension.Data, gsData.incoming)
 			},
 		},
+		"recognized incoming request will record network error": {
+			action: func(gsData *harness) {
+				gsData.incomingRequestHook()
+				gsData.networkErrorListener(errors.New("something went wrong"))
+			},
+			check: func(t *testing.T, events *fakeEvents, gsData *harness) {
+				require.Equal(t, 1, events.OnRequestReceivedCallCount)
+				require.True(t, events.OnRequestDisconnectedCalled)
+			},
+		},
 		"open channel adds doNotSendCids to the DoNotSend extension": {
 			action: func(gsData *harness) {
 				cids := testutil.GenerateCids(2)
@@ -684,6 +694,85 @@ func TestManager(t *testing.T) {
 
 				require.Error(t, requestReceived1.Ctx.Err())
 				require.NoError(t, requestReceived2.Ctx.Err())
+			},
+		},
+		"OnChannelCompleted called when outgoing request completes successfully": {
+			action: func(gsData *harness) {
+				gsData.fgs.LeaveRequestsOpen()
+				stor, _ := gsData.outgoing.Selector()
+
+				_ = gsData.transport.OpenChannel(
+					gsData.ctx,
+					gsData.other,
+					datatransfer.ChannelID{ID: gsData.transferID, Responder: gsData.other, Initiator: gsData.self},
+					cidlink.Link{Cid: gsData.outgoing.BaseCid()},
+					stor,
+					nil,
+					gsData.outgoing)
+			},
+			check: func(t *testing.T, events *fakeEvents, gsData *harness) {
+				requestReceived := gsData.fgs.AssertRequestReceived(gsData.ctx, t)
+				close(requestReceived.ResponseErrChan)
+
+				require.Eventually(t, func() bool {
+					return events.OnChannelCompletedCalled == true
+				}, 2*time.Second, 100*time.Millisecond)
+				require.True(t, events.ChannelCompletedSuccess)
+			},
+		},
+		"OnChannelCompleted called when outgoing request completes with error": {
+			action: func(gsData *harness) {
+				gsData.fgs.LeaveRequestsOpen()
+				stor, _ := gsData.outgoing.Selector()
+
+				_ = gsData.transport.OpenChannel(
+					gsData.ctx,
+					gsData.other,
+					datatransfer.ChannelID{ID: gsData.transferID, Responder: gsData.other, Initiator: gsData.self},
+					cidlink.Link{Cid: gsData.outgoing.BaseCid()},
+					stor,
+					nil,
+					gsData.outgoing)
+			},
+			check: func(t *testing.T, events *fakeEvents, gsData *harness) {
+				requestReceived := gsData.fgs.AssertRequestReceived(gsData.ctx, t)
+				requestReceived.ResponseErrChan <- graphsync.RequestFailedUnknownErr{}
+				close(requestReceived.ResponseErrChan)
+
+				require.Eventually(t, func() bool {
+					return events.OnChannelCompletedCalled == true
+				}, 2*time.Second, 100*time.Millisecond)
+				require.False(t, events.ChannelCompletedSuccess)
+			},
+		},
+		"OnChannelComplete when outgoing request cancelled by caller": {
+			action: func(gsData *harness) {
+				gsData.fgs.LeaveRequestsOpen()
+				stor, _ := gsData.outgoing.Selector()
+
+				_ = gsData.transport.OpenChannel(
+					gsData.ctx,
+					gsData.other,
+					datatransfer.ChannelID{ID: gsData.transferID, Responder: gsData.other, Initiator: gsData.self},
+					cidlink.Link{Cid: gsData.outgoing.BaseCid()},
+					stor,
+					nil,
+					gsData.outgoing)
+
+				gsData.outgoingRequestHook()
+			},
+			check: func(t *testing.T, events *fakeEvents, gsData *harness) {
+				requestReceived := gsData.fgs.AssertRequestReceived(gsData.ctx, t)
+				extensions := make(map[graphsync.ExtensionName][]byte)
+				for _, ext := range requestReceived.Extensions {
+					extensions[ext.Name] = ext.Data
+				}
+				request := testutil.NewFakeRequest(graphsync.RequestID(rand.Int31()), extensions)
+				gsData.fgs.OutgoingRequestHook(gsData.other, request, gsData.outgoingRequestHookActions)
+				_ = gsData.transport.CloseChannel(gsData.ctx, datatransfer.ChannelID{ID: gsData.transferID, Responder: gsData.other, Initiator: gsData.self})
+				require.Eventually(t, func() bool {
+					return requestReceived.Ctx.Err() != nil
+				}, 2*time.Second, 100*time.Millisecond)
 			},
 		},
 		"request times out if we get request context cancelled error": {
@@ -849,8 +938,10 @@ type fakeEvents struct {
 	OnChannelCompletedCalled    bool
 	OnChannelCompletedErr       error
 
-	OnRequestTimedOutCalled    bool
-	OnRequestTimedOutChannelId datatransfer.ChannelID
+	OnRequestTimedOutCalled        bool
+	OnRequestTimedOutChannelId     datatransfer.ChannelID
+	OnRequestDisconnectedCalled    bool
+	OnRequestDisconnectedChannelID datatransfer.ChannelID
 
 	ChannelCompletedSuccess  bool
 	DataSentMessage          datatransfer.Message
@@ -863,6 +954,12 @@ func (fe *fakeEvents) OnRequestTimedOut(_ context.Context, chid datatransfer.Cha
 	fe.OnRequestTimedOutCalled = true
 	fe.OnRequestTimedOutChannelId = chid
 
+	return nil
+}
+
+func (fe *fakeEvents) OnRequestDisconnected(_ context.Context, chid datatransfer.ChannelID) error {
+	fe.OnRequestDisconnectedCalled = true
+	fe.OnRequestDisconnectedChannelID = chid
 	return nil
 }
 
@@ -953,6 +1050,12 @@ func (ha *harness) responseCompletedListener() {
 }
 func (ha *harness) requestorCancelledListener() {
 	ha.fgs.RequestorCancelledListener(ha.other, ha.request)
+}
+func (ha *harness) blockSentListener() {
+	ha.fgs.BlockSentListener(ha.other, ha.request, ha.block)
+}
+func (ha *harness) networkErrorListener(err error) {
+	ha.fgs.NetworkErrorListener(ha.other, ha.request, err)
 }
 
 type dtConfig struct {

--- a/transport/graphsync/graphsync_test.go
+++ b/transport/graphsync/graphsync_test.go
@@ -1051,9 +1051,6 @@ func (ha *harness) responseCompletedListener() {
 func (ha *harness) requestorCancelledListener() {
 	ha.fgs.RequestorCancelledListener(ha.other, ha.request)
 }
-func (ha *harness) blockSentListener() {
-	ha.fgs.BlockSentListener(ha.other, ha.request, ha.block)
-}
 func (ha *harness) networkErrorListener(err error) {
 	ha.fgs.NetworkErrorListener(ha.other, ha.request, err)
 }


### PR DESCRIPTION
# Goals

Using https://github.com/ipfs/go-graphsync/pull/102, provide better information about what's going on with a request and when it stalls.

# Implementation

- Change the FSM behvaior of Disconnected - remove the PeerDisconnected state, and instead just have it set an informational message that we believe the other peer to be stalled. The reason we want to do this is the actual idea behavior here should be that we go into a PeerDisconnected state, and when we come out of it, we reset to the state we were in before the disconnection. Our FSM module really doesn't support this well, so for the time being, I'm just removing the state change and setting a message -- we weren't really doing anything based on being in PeerDisconnected and it was ultimately a black-hole state. (I think PeerDisconnected was meant to handle the fact that graphsync requests were going into an error state when the peers were unlinked -- due to a message send failure in OnChannelCompleted)
- Change the FSM behavior of Restart -- it actually should do nothing to the state. The only reason we were changing it to Ongoing was to resolve the PeerDisconnected state, and there are several issues that could arise from forcing into the Ongoing state -- we should instead preserve the state of the request overall!
- Convert a channel removed due to inactivity to an Error -- this is not a request cancelled by a user but rather something bad that happened
- Add a new event to the Events interface -- OnRequestDisconnected, which occurs when the transport protocol believes there's been a network disconnection (different from OnRequestTimedOut which occurs when request is cancelled due to a restart)
- Convert ChannelRemoveTimeout to a configurable param on the data transfer manager
- Hook into the new NetworkError hook in go-graphsync to detect disconnections
- Convert some message sent failure to request disconnections rather than channel errors -- cause data transfer is an ongoing process, we shouldn't fail the channel entirely just cause a message doesn't go through -- we may want to restart the channel
- Buff out a few tests for the graphsync transport protocol