### PR TITLE
Correct data transfer Sent stats

### DIFF
--- a/channels/channel_state.go
+++ b/channels/channel_state.go
@@ -34,6 +34,8 @@ type channelState struct {
 	status datatransfer.Status
 	// isPull indicates if this is a push or pull request
 	isPull bool
+	// total bytes read from this node and queued for sending (0 if receiver)
+	queued uint64
 	// total bytes sent from this node (0 if receiver)
 	sent uint64
 	// total bytes received by this node (0 if sender)
@@ -55,6 +57,9 @@ var EmptyChannelState = channelState{}
 
 // Status is the current status of this channel
 func (c channelState) Status() datatransfer.Status { return c.status }
+
+// Received returns the number of bytes received
+func (c channelState) Queued() uint64 { return c.queued }
 
 // Sent returns the number of bytes sent
 func (c channelState) Sent() uint64 { return c.sent }
@@ -171,6 +176,7 @@ func fromInternalChannelState(c internal.ChannelState, voucherDecoder DecoderByT
 		recipient:            c.Recipient,
 		totalSize:            c.TotalSize,
 		status:               c.Status,
+		queued:               c.Queued,
 		sent:                 c.Sent,
 		received:             c.Received,
 		message:              c.Message,

--- a/channels/channels.go
+++ b/channels/channels.go
@@ -190,6 +190,10 @@ func (c *Channels) DataSent(chid datatransfer.ChannelID, cid cid.Cid, delta uint
 	return c.send(chid, datatransfer.DataSent, delta, cid)
 }
 
+func (c *Channels) DataQueued(chid datatransfer.ChannelID, cid cid.Cid, delta uint64) error {
+	return c.send(chid, datatransfer.DataQueued, delta, cid)
+}
+
 func (c *Channels) DataReceived(chid datatransfer.ChannelID, cid cid.Cid, delta uint64) error {
 	return c.send(chid, datatransfer.DataReceived, delta, cid)
 }

--- a/channels/channels_fsm.go
+++ b/channels/channels_fsm.go
@@ -48,7 +48,17 @@ var ChannelEvents = fsm.Events{
 		chst.Sent += delta
 		return nil
 	}),
-
+	fsm.Event(datatransfer.DataQueued).FromMany(
+		datatransfer.Requested,
+		datatransfer.Ongoing,
+		datatransfer.InitiatorPaused,
+		datatransfer.ResponderPaused,
+		datatransfer.BothPaused,
+		datatransfer.ResponderCompleted,
+		datatransfer.ResponderFinalizing).ToNoChange().Action(func(chst *internal.ChannelState, delta uint64, c cid.Cid) error {
+		chst.Queued += delta
+		return nil
+	}),
 	fsm.Event(datatransfer.Disconnected).FromAny().ToNoChange().Action(func(chst *internal.ChannelState) error {
 		chst.Message = datatransfer.ErrDisconnected.Error()
 		return nil

--- a/channels/internal/internalchannel.go
+++ b/channels/internal/internalchannel.go
@@ -48,6 +48,8 @@ type ChannelState struct {
 	TotalSize uint64
 	// current status of this deal
 	Status datatransfer.Status
+	// total bytes read from this node and queued for sending (0 if receiver)
+	Queued uint64
 	// total bytes sent from this node (0 if receiver)
 	Sent uint64
 	// total bytes received by this node (0 if sender)

--- a/channels/internal/internalchannel_cbor_gen.go
+++ b/channels/internal/internalchannel_cbor_gen.go
@@ -20,7 +20,7 @@ func (t *ChannelState) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{176}); err != nil {
+	if _, err := w.Write([]byte{177}); err != nil {
 		return err
 	}
 
@@ -218,6 +218,22 @@ func (t *ChannelState) MarshalCBOR(w io.Writer) error {
 	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Status)); err != nil {
+		return err
+	}
+
+	// t.Queued (uint64) (uint64)
+	if len("Queued") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Queued\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Queued"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Queued")); err != nil {
+		return err
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Queued)); err != nil {
 		return err
 	}
 
@@ -508,6 +524,21 @@ func (t *ChannelState) UnmarshalCBOR(r io.Reader) error {
 					return fmt.Errorf("wrong type for uint64 field")
 				}
 				t.Status = datatransfer.Status(extra)
+
+			}
+			// t.Queued (uint64) (uint64)
+		case "Queued":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.Queued = uint64(extra)
 
 			}
 			// t.Sent (uint64) (uint64)

--- a/events.go
+++ b/events.go
@@ -70,6 +70,9 @@ const (
 	// CompleteCleanupOnRestart is emitted when a data transfer channel is restarted to signal
 	// that channels that were cleaning up should finish cleanup
 	CompleteCleanupOnRestart
+
+	// DataQueued is emmited is read and queued for sending to the remote peer
+	DataQueued
 )
 
 // Events are human readable names for data transfer events
@@ -93,6 +96,7 @@ var Events = map[EventCode]string{
 	BeginFinalizing:             "BeginFinalizing",
 	Complete:                    "Complete",
 	CompleteCleanupOnRestart:    "CompleteCleanupOnRestart",
+	DataQueued:                  "DataQueued",
 }
 
 // Event is a struct containing information about a data transfer event

--- a/impl/events.go
+++ b/impl/events.go
@@ -58,11 +58,7 @@ func (m *manager) OnDataReceived(chid datatransfer.ChannelID, link ipld.Link, si
 	return nil
 }
 
-func (m *manager) OnDataSent(chid datatransfer.ChannelID, link ipld.Link, size uint64) (datatransfer.Message, error) {
-	err := m.channels.DataSent(chid, link.(cidlink.Link).Cid, size)
-	if err != nil {
-		return nil, err
-	}
+func (m *manager) OnDataQueued(chid datatransfer.ChannelID, link ipld.Link, size uint64) (datatransfer.Message, error) {
 	if chid.Initiator != m.peerID {
 		var result datatransfer.VoucherResult
 		var err error
@@ -79,7 +75,12 @@ func (m *manager) OnDataSent(chid datatransfer.ChannelID, link ipld.Link, size u
 			return m.processRevalidationResult(chid, result, err)
 		}
 	}
+
 	return nil, nil
+}
+
+func (m *manager) OnDataSent(chid datatransfer.ChannelID, link ipld.Link, size uint64) error {
+	return m.channels.DataSent(chid, link.(cidlink.Link).Cid, size)
 }
 
 func (m *manager) OnRequestReceived(chid datatransfer.ChannelID, request datatransfer.Request) (datatransfer.Response, error) {

--- a/impl/events.go
+++ b/impl/events.go
@@ -59,6 +59,9 @@ func (m *manager) OnDataReceived(chid datatransfer.ChannelID, link ipld.Link, si
 }
 
 func (m *manager) OnDataQueued(chid datatransfer.ChannelID, link ipld.Link, size uint64) (datatransfer.Message, error) {
+	if err := m.channels.DataQueued(chid, link.(cidlink.Link).Cid, size); err != nil {
+		return nil, err
+	}
 	if chid.Initiator != m.peerID {
 		var result datatransfer.VoucherResult
 		var err error

--- a/impl/integration_test.go
+++ b/impl/integration_test.go
@@ -56,7 +56,7 @@ var protocolsForTest = map[string]struct {
 	"(new, old -> old)": {nil, []protocol.ID{datatransfer.ProtocolDataTransfer1_0}},
 }
 
-/*func TestRoundTrip(t *testing.T) {
+func TestRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	testCases := map[string]struct {
 		isPull            bool
@@ -117,9 +117,9 @@ var protocolsForTest = map[string]struct {
 				sent := make(chan uint64, 21)
 				received := make(chan uint64, 21)
 				var subscriber datatransfer.Subscriber = func(event datatransfer.Event, channelState datatransfer.ChannelState) {
-					if event.Code == datatransfer.DataSent {
-						if channelState.Sent() > 0 {
-							sent <- channelState.Sent()
+					if event.Code == datatransfer.DataQueued {
+						if channelState.Queued() > 0 {
+							sent <- channelState.Queued()
 						}
 					}
 
@@ -231,7 +231,7 @@ var protocolsForTest = map[string]struct {
 			})
 		}
 	} //
-}*/
+}
 
 func TestMultipleRoundTripMultipleStores(t *testing.T) {
 	ctx := context.Background()
@@ -805,9 +805,9 @@ func TestPauseAndResume(t *testing.T) {
 			resumeResponder := make(chan struct{}, 2)
 			var subscriber datatransfer.Subscriber = func(event datatransfer.Event, channelState datatransfer.ChannelState) {
 
-				if event.Code == datatransfer.DataSent {
-					if channelState.Sent() > 0 {
-						sent <- channelState.Sent()
+				if event.Code == datatransfer.DataQueued {
+					if channelState.Queued() > 0 {
+						sent <- channelState.Queued()
 					}
 				}
 

--- a/impl/integration_test.go
+++ b/impl/integration_test.go
@@ -56,7 +56,7 @@ var protocolsForTest = map[string]struct {
 	"(new, old -> old)": {nil, []protocol.ID{datatransfer.ProtocolDataTransfer1_0}},
 }
 
-func TestRoundTrip(t *testing.T) {
+/*func TestRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	testCases := map[string]struct {
 		isPull            bool
@@ -231,7 +231,7 @@ func TestRoundTrip(t *testing.T) {
 			})
 		}
 	} //
-}
+}*/
 
 func TestMultipleRoundTripMultipleStores(t *testing.T) {
 	ctx := context.Background()
@@ -776,7 +776,7 @@ func TestPauseAndResume(t *testing.T) {
 	}
 	for testCase, isPull := range testCases {
 		t.Run(testCase, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 			defer cancel()
 
 			gsData := testutil.NewGraphsyncTestingData(ctx, t, nil, nil)

--- a/impl/responding_test.go
+++ b/impl/responding_test.go
@@ -395,6 +395,7 @@ func TestDataTransferResponding(t *testing.T) {
 				datatransfer.Open,
 				datatransfer.NewVoucherResult,
 				datatransfer.Accept,
+				datatransfer.DataQueued,
 				datatransfer.NewVoucherResult,
 				datatransfer.PauseResponder,
 				datatransfer.NewVoucher,

--- a/impl/responding_test.go
+++ b/impl/responding_test.go
@@ -395,7 +395,6 @@ func TestDataTransferResponding(t *testing.T) {
 				datatransfer.Open,
 				datatransfer.NewVoucherResult,
 				datatransfer.Accept,
-				datatransfer.DataSent,
 				datatransfer.NewVoucherResult,
 				datatransfer.PauseResponder,
 				datatransfer.NewVoucher,
@@ -415,7 +414,7 @@ func TestDataTransferResponding(t *testing.T) {
 			verify: func(t *testing.T, h *receiverHarness) {
 				_, err := h.transport.EventHandler.OnRequestReceived(channelID(h.id, h.peers), h.pullRequest)
 				require.NoError(t, err)
-				msg, err := h.transport.EventHandler.OnDataSent(
+				msg, err := h.transport.EventHandler.OnDataQueued(
 					channelID(h.id, h.peers),
 					cidlink.Link{Cid: testutil.GenerateCids(1)[0]},
 					12345)

--- a/impl/restart_integration_test.go
+++ b/impl/restart_integration_test.go
@@ -101,9 +101,9 @@ func TestRestartPush(t *testing.T) {
 			disConnChan := make(chan struct{})
 
 			var subscriber datatransfer.Subscriber = func(event datatransfer.Event, channelState datatransfer.ChannelState) {
-				if event.Code == datatransfer.DataSent {
-					if channelState.Sent() > 0 {
-						sent <- channelState.Sent()
+				if event.Code == datatransfer.DataQueued {
+					if channelState.Queued() > 0 {
+						sent <- channelState.Queued()
 					}
 				}
 
@@ -289,9 +289,9 @@ func TestRestartPull(t *testing.T) {
 			disConnChan := make(chan struct{})
 
 			var subscriber datatransfer.Subscriber = func(event datatransfer.Event, channelState datatransfer.ChannelState) {
-				if event.Code == datatransfer.DataSent {
-					if channelState.Sent() > 0 {
-						sent <- channelState.Sent()
+				if event.Code == datatransfer.DataQueued {
+					if channelState.Queued() > 0 {
+						sent <- channelState.Queued()
 					}
 				}
 

--- a/transport.go
+++ b/transport.go
@@ -26,14 +26,19 @@ type EventsHandler interface {
 	// - error = cancel this request
 	// - err == ErrPause - pause this request
 	OnDataReceived(chid ChannelID, link ipld.Link, size uint64) error
-	// OnDataSent is called when we send data for the given channel ID
+
+	// OnDataQueued is called when data is queued for sending for the given channel ID
 	// return values are:
 	// message = data transfer message along with data
 	// err = error
 	// - nil = proceed with sending data
 	// - error = cancel this request
 	// - err == ErrPause - pause this request
-	OnDataSent(chid ChannelID, link ipld.Link, size uint64) (Message, error)
+	OnDataQueued(chid ChannelID, link ipld.Link, size uint64) (Message, error)
+
+	// OnDataSent is called when we send data for the given channel ID
+	OnDataSent(chid ChannelID, link ipld.Link, size uint64) error
+
 	// OnRequestReceived is called when we receive a new request to send data
 	// for the given channel ID
 	// return values are:

--- a/types.go
+++ b/types.go
@@ -94,9 +94,6 @@ type Channel interface {
 
 	// OtherPeer returns the counter party peer for this channel
 	OtherPeer() peer.ID
-
-	// ReceivedCids returns the cids received so far on the channel
-	ReceivedCids() []cid.Cid
 }
 
 // ChannelState is channel parameters plus it's current state
@@ -129,4 +126,10 @@ type ChannelState interface {
 
 	// LastVoucherResult returns the last voucher result sent on the channel
 	LastVoucherResult() VoucherResult
+
+	// ReceivedCids returns the cids received so far on the channel
+	ReceivedCids() []cid.Cid
+
+	// Queued returns the number of bytes read from the node and queued for sending
+	Queued() uint64
 }


### PR DESCRIPTION
For https://github.com/filecoin-project/lotus/issues/4381.

@hannahhoward 

I still need into why some tests are failing. They depend on the `Sent` stats on the Channel and we have now changed how we tracked them i.e. we update them when we actually send the blocks. 

Let me know if you have any thoughts on those. 