### PR TITLE
Don't error on close data transfer if transport channel is not open

### DIFF
--- a/impl/impl.go
+++ b/impl/impl.go
@@ -262,7 +262,7 @@ func (m *manager) CloseDataTransferChannel(ctx context.Context, chid datatransfe
 	}
 	err = m.transport.CloseChannel(ctx, chid)
 	if err != nil {
-		return err
+		log.Warnf("unable to close channel: %w", err)
 	}
 
 	if err := m.dataTransferNetwork.SendMessage(ctx, chst.OtherPeer(), m.cancelMessage(chid)); err != nil {


### PR DESCRIPTION
# Goals

When CloseDataTransferChannel is called, if the node has restarted, likely there may be no open channel at the transport level. Therefore, we should not error, and, instead, just log a warning