### PR TITLE
Reset timeouts

### DIFF
--- a/impl/environment.go
+++ b/impl/environment.go
@@ -23,5 +23,8 @@ func (ce *channelEnvironment) ID() peer.ID {
 }
 
 func (ce *channelEnvironment) CleanupChannel(chid datatransfer.ChannelID) {
+	ce.m.reconnectsLk.Lock()
+	delete(ce.m.reconnects, chid)
+	ce.m.reconnectsLk.Unlock()
 	ce.m.transport.CleanupChannel(chid)
 }


### PR DESCRIPTION
# Goals

Prevent Disconnects and Timeouts from shutting down the channel automatically if it doesn't close within an hour.

# Implementation

- Setup a series of channels that indicate the request has resumed operating (via receiving new data)
- Stop the go routine waiting for the timeout when the request resumes.

- couple other mutex things:
   - want to avoid a write lock in DataSent/DataReceived, so they use an RLock and then close the channel, checking to see if its already closed
   - then the actual channel is thrown out when we get another disconnect
   - not worried about race condition on multiple close because within a single request, calls to DataSent/DataReceived are sequential