### PR TITLE
Fix UseStore for restarts

### DIFF
--- a/transport/graphsync/graphsync.go
+++ b/transport/graphsync/graphsync.go
@@ -318,13 +318,17 @@ func (t *Transport) Shutdown(ctx context.Context) error {
 
 // UseStore tells the graphsync transport to use the given loader and storer for this channelID
 func (t *Transport) UseStore(channelID datatransfer.ChannelID, loader ipld.Loader, storer ipld.Storer) error {
+	t.dataLock.Lock()
+	defer t.dataLock.Unlock()
+	_, ok := t.stores[channelID]
+	if ok {
+		return nil
+	}
 	err := t.gs.RegisterPersistenceOption("data-transfer-"+channelID.String(), loader, storer)
 	if err != nil {
 		return err
 	}
-	t.dataLock.Lock()
 	t.stores[channelID] = struct{}{}
-	t.dataLock.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
# Goals

Fix UseStore in the case when a request is restarted -- sometimes this produces an error that causes a failure to use a custom store.

# Implementation

Unregister any existing stores when restarting.