### PR TITLE
Fire cancel locally even if remote cancel fails

### DIFF
--- a/network/libp2p_impl.go
+++ b/network/libp2p_impl.go
@@ -99,8 +99,13 @@ func (impl *libp2pDataTransferNetwork) openStream(ctx context.Context, id peer.I
 		if nAttempts == impl.maxStreamOpenAttempts {
 			return nil, xerrors.Errorf("exhausted %d attempts but failed to open stream, err: %w", impl.maxStreamOpenAttempts, err)
 		}
+
 		d := b.Duration()
-		time.Sleep(d)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(d):
+		}
 	}
 }
 


### PR DESCRIPTION
CloseDataTransferChannel should fire "cancel" on the local FSM, even if sending a "cancel" message to the remote peer fails