### PR TITLE
Wrap correct FSM error when closing a channel 

### DIFF
--- a/impl/impl.go
+++ b/impl/impl.go
@@ -275,7 +275,7 @@ func (m *manager) CloseDataTransferChannel(ctx context.Context, chid datatransfe
 		return err
 	}
 	if fsmerr != nil {
-		return xerrors.Errorf("unable to send cancel to channel FSM: %w", err)
+		return xerrors.Errorf("unable to send cancel to channel FSM: %w", fsmerr)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
Fixing a typo, which caused the wrong error to be wrapped, preventing proper error inspection by callers