### PR TITLE
Expose channel state on Manager interface

### DIFF
--- a/impl/impl.go
+++ b/impl/impl.go
@@ -318,6 +318,11 @@ func (m *manager) ResumeDataTransferChannel(ctx context.Context, chid datatransf
 	return m.resume(chid)
 }
 
+// get channel state
+func (m *manager) ChannelState(ctx context.Context, chid datatransfer.ChannelID) (datatransfer.ChannelState, error) {
+	return m.channels.GetByID(ctx, chid)
+}
+
 // get status of a transfer
 func (m *manager) TransferChannelStatus(ctx context.Context, chid datatransfer.ChannelID) datatransfer.Status {
 	chst, err := m.channels.GetByID(ctx, chid)

--- a/manager.go
+++ b/manager.go
@@ -119,6 +119,9 @@ type Manager interface {
 	// get status of a transfer
 	TransferChannelStatus(ctx context.Context, x ChannelID) Status
 
+	// get channel state
+	ChannelState(ctx context.Context, chid ChannelID) (ChannelState, error)
+
 	// get notified when certain types of events happen
 	SubscribeToEvents(subscriber Subscriber) Unsubscribe
 


### PR DESCRIPTION
This is needed so that more information about a data transfer can be displayed in lotus CLI