### PR TITLE
limit consecutive restarts with no data transfer

### DIFF
--- a/impl/impl.go
+++ b/impl/impl.go
@@ -95,20 +95,26 @@ func ChannelRemoveTimeout(timeout time.Duration) DataTransferOption {
 // restarting push channels
 // - interval is the time over which minBytesSent must have been sent
 // - checksPerInterval is the number of times to check per interval
-// - minBytesSent is the minimum amount of data that must have been sent over the interval
+// - minBytesSent is the minimum amount of data that must have been sent over
+//   the interval
 // - restartBackoff is the time to wait before checking again for restarts
+// - maxConsecutiveRestarts is the maximum number of restarts in a row to
+//   attempt where no data is transferred. When the limit is reached the
+//   channel is closed.
 func PushChannelRestartConfig(
 	interval time.Duration,
 	checksPerInterval uint32,
 	minBytesSent uint64,
 	restartBackoff time.Duration,
+	maxConsecutiveRestarts uint32,
 ) DataTransferOption {
 	return func(m *manager) {
 		m.pushChannelMonitorCfg = &pushchannelmonitor.Config{
-			Interval:          interval,
-			ChecksPerInterval: checksPerInterval,
-			MinBytesSent:      minBytesSent,
-			RestartBackoff:    restartBackoff,
+			Interval:               interval,
+			ChecksPerInterval:      checksPerInterval,
+			MinBytesSent:           minBytesSent,
+			RestartBackoff:         restartBackoff,
+			MaxConsecutiveRestarts: maxConsecutiveRestarts,
 		}
 	}
 }

--- a/impl/integration_test.go
+++ b/impl/integration_test.go
@@ -513,7 +513,7 @@ func TestPushRequestAutoRestart(t *testing.T) {
 	tp1 := gsData.SetupGSTransportHost1()
 	tp2 := gsData.SetupGSTransportHost2()
 
-	restartConf := PushChannelRestartConfig(100*time.Millisecond, 1, 10, 200*time.Millisecond)
+	restartConf := PushChannelRestartConfig(100*time.Millisecond, 1, 10, 200*time.Millisecond, 5)
 	dt1, err := NewDataTransfer(gsData.DtDs1, gsData.TempDir1, gsData.DtNet1, tp1, gsData.StoredCounter1, restartConf)
 	require.NoError(t, err)
 	testutil.StartAndWaitForReady(ctx, t, dt1)


### PR DESCRIPTION
Needed for https://github.com/filecoin-project/lotus/issues/5211

Currently when a push channel stalls (no data is sent for a while) the push channel monitor will attempt to restart the channel.
It's possible that the monitor will keep restarting the channel forever, and the transfer will get stuck.

This PR adds a configurable parameter `maxConsecutiveRestarts` - the maximum number of restarts in a row to attempt where no data is transferred. When the limit is reached the channel is closed.