### PR TITLE
Update to go-graphsync v0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-datastore v0.4.5
 	github.com/ipfs/go-ds-badger v0.2.3
-	github.com/ipfs/go-graphsync v0.5.2
+	github.com/ipfs/go-graphsync v0.6.0
 	github.com/ipfs/go-ipfs-blockstore v1.0.1
 	github.com/ipfs/go-ipfs-blocksutil v0.0.1
 	github.com/ipfs/go-ipfs-chunker v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/ipfs/go-ds-badger v0.2.3/go.mod h1:pEYw0rgg3FIrywKKnL+Snr+w/LjJZVMTBR
 github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIykR4L04tMOYc=
 github.com/ipfs/go-ds-leveldb v0.4.1/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1Ii2r79Hh9s=
 github.com/ipfs/go-ds-leveldb v0.4.2/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1Ii2r79Hh9s=
-github.com/ipfs/go-graphsync v0.5.2 h1:USD+daaSC+7pLHCxROThSaF6SF7WYXF03sjrta0rCfA=
-github.com/ipfs/go-graphsync v0.5.2/go.mod h1:e2ZxnClqBBYAtd901g9vXMJzS47labjAtOzsWtOzKNk=
+github.com/ipfs/go-graphsync v0.6.0 h1:x6UvDUGA7wjaKNqx5Vbo7FGT8aJ5ryYA0dMQ5jN3dF0=
+github.com/ipfs/go-graphsync v0.6.0/go.mod h1:e2ZxnClqBBYAtd901g9vXMJzS47labjAtOzsWtOzKNk=
 github.com/ipfs/go-ipfs-blockstore v0.0.1/go.mod h1:d3WClOmRQKFnJ0Jz/jj/zmksX0ma1gROTlovZKBmN08=
 github.com/ipfs/go-ipfs-blockstore v0.1.0/go.mod h1:5aD0AvHPi7mZc6Ci1WCAhiBQu2IsfTduLl+422H6Rqw=
 github.com/ipfs/go-ipfs-blockstore v0.1.4 h1:2SGI6U1B44aODevza8Rde3+dY30Pb+lbcObe1LETxOQ=

--- a/impl/integration_test.go
+++ b/impl/integration_test.go
@@ -1186,7 +1186,7 @@ func (fgsr *fakeGraphSyncReceiver) ReceiveMessage(ctx context.Context, sender pe
 	}
 }
 
-func (fgsr *fakeGraphSyncReceiver) ReceiveError(_ error) {
+func (fgsr *fakeGraphSyncReceiver) ReceiveError(_ peer.ID, _ error) {
 }
 func (fgsr *fakeGraphSyncReceiver) Connected(p peer.ID) {
 }
@@ -1262,8 +1262,10 @@ func TestRespondingToPushGraphsyncRequests(t *testing.T) {
 			Name: extension.ExtensionDataTransfer1_1,
 			Data: extData,
 		})
-		gsmessage := gsmsg.New()
-		gsmessage.AddRequest(request)
+		builder := gsmsg.NewBuilder(0)
+		builder.AddRequest(request)
+		gsmessage, err := builder.Build()
+		require.NoError(t, err)
 		require.NoError(t, gsData.GsNet2.SendMessage(ctx, host1.ID(), gsmessage))
 
 		status := gsr.consumeResponses(ctx, t)
@@ -1282,8 +1284,10 @@ func TestRespondingToPushGraphsyncRequests(t *testing.T) {
 			Name: extension.ExtensionDataTransfer1_1,
 			Data: extData,
 		})
-		gsmessage := gsmsg.New()
-		gsmessage.AddRequest(request)
+		builder := gsmsg.NewBuilder(0)
+		builder.AddRequest(request)
+		gsmessage, err := builder.Build()
+		require.NoError(t, err)
 		require.NoError(t, gsData.GsNet2.SendMessage(ctx, host1.ID(), gsmessage))
 
 		status := gsr.consumeResponses(ctx, t)
@@ -1337,8 +1341,10 @@ func TestResponseHookWhenExtensionNotFound(t *testing.T) {
 		}
 
 		request := gsmsg.NewRequest(graphsync.RequestID(rand.Int31()), link.(cidlink.Link).Cid, gsData.AllSelector, graphsync.Priority(rand.Int31()))
-		gsmessage := gsmsg.New()
-		gsmessage.AddRequest(request)
+		builder := gsmsg.NewBuilder(0)
+		builder.AddRequest(request)
+		gsmessage, err := builder.Build()
+		require.NoError(t, err)
 		require.NoError(t, gsData.GsNet2.SendMessage(ctx, host1.ID(), gsmessage))
 
 		status := gsr.consumeResponses(ctx, t)
@@ -1376,8 +1382,10 @@ func TestRespondingToPullGraphsyncRequests(t *testing.T) {
 				})
 
 				// initiator requests data over graphsync network
-				gsmessage := gsmsg.New()
-				gsmessage.AddRequest(gsRequest)
+				builder := gsmsg.NewBuilder(0)
+				builder.AddRequest(gsRequest)
+				gsmessage, err := builder.Build()
+				require.NoError(t, err)
 				require.NoError(t, gsData.GsNet1.SendMessage(ctx, gsData.Host2.ID(), gsmessage))
 				status := gsr.consumeResponses(ctx, t)
 				require.False(t, gsmsg.IsTerminalFailureCode(status))
@@ -1403,8 +1411,10 @@ func TestRespondingToPullGraphsyncRequests(t *testing.T) {
 					Name: extension.ExtensionDataTransfer1_1,
 					Data: extData,
 				})
-				gsmessage := gsmsg.New()
-				gsmessage.AddRequest(request)
+				builder := gsmsg.NewBuilder(0)
+				builder.AddRequest(request)
+				gsmessage, err := builder.Build()
+				require.NoError(t, err)
 
 				// non-initiator requests data over graphsync network, but should not get it
 				// because there was no previous request

--- a/testutil/fakegraphsync.go
+++ b/testutil/fakegraphsync.go
@@ -94,25 +94,26 @@ type PersistenceOption struct {
 
 // FakeGraphSync implements a GraphExchange but does nothing
 type FakeGraphSync struct {
-	requests                   chan ReceivedGraphSyncRequest // records calls to fakeGraphSync.Request
-	pauseRequests              chan PauseRequest
-	resumeRequests             chan ResumeRequest
-	pauseResponses             chan PauseResponse
-	resumeResponses            chan ResumeResponse
-	cancelResponses            chan CancelResponse
-	persistenceOptionsLk       sync.RWMutex
-	persistenceOptions         map[string]PersistenceOption
-	leaveRequestsOpen          bool
-	OutgoingRequestHook        graphsync.OnOutgoingRequestHook
-	IncomingBlockHook          graphsync.OnIncomingBlockHook
-	OutgoingBlockHook          graphsync.OnOutgoingBlockHook
-	IncomingRequestHook        graphsync.OnIncomingRequestHook
-	CompletedResponseListener  graphsync.OnResponseCompletedListener
-	RequestUpdatedHook         graphsync.OnRequestUpdatedHook
-	IncomingResponseHook       graphsync.OnIncomingResponseHook
-	RequestorCancelledListener graphsync.OnRequestorCancelledListener
-	BlockSentListener          graphsync.OnBlockSentListener
-	NetworkErrorListener       graphsync.OnNetworkErrorListener
+	requests                     chan ReceivedGraphSyncRequest // records calls to fakeGraphSync.Request
+	pauseRequests                chan PauseRequest
+	resumeRequests               chan ResumeRequest
+	pauseResponses               chan PauseResponse
+	resumeResponses              chan ResumeResponse
+	cancelResponses              chan CancelResponse
+	persistenceOptionsLk         sync.RWMutex
+	persistenceOptions           map[string]PersistenceOption
+	leaveRequestsOpen            bool
+	OutgoingRequestHook          graphsync.OnOutgoingRequestHook
+	IncomingBlockHook            graphsync.OnIncomingBlockHook
+	OutgoingBlockHook            graphsync.OnOutgoingBlockHook
+	IncomingRequestHook          graphsync.OnIncomingRequestHook
+	CompletedResponseListener    graphsync.OnResponseCompletedListener
+	RequestUpdatedHook           graphsync.OnRequestUpdatedHook
+	IncomingResponseHook         graphsync.OnIncomingResponseHook
+	RequestorCancelledListener   graphsync.OnRequestorCancelledListener
+	BlockSentListener            graphsync.OnBlockSentListener
+	NetworkErrorListener         graphsync.OnNetworkErrorListener
+	ReceiverNetworkErrorListener graphsync.OnReceiverNetworkErrorListener
 }
 
 // NewFakeGraphSync returns a new fake graphsync implementation
@@ -384,6 +385,14 @@ func (fgs *FakeGraphSync) RegisterNetworkErrorListener(listener graphsync.OnNetw
 	fgs.NetworkErrorListener = listener
 	return func() {
 		fgs.NetworkErrorListener = nil
+	}
+}
+
+// RegisterNetworkErrorListener adds a listener on the responder as blocks go out
+func (fgs *FakeGraphSync) RegisterReceiverNetworkErrorListener(listener graphsync.OnReceiverNetworkErrorListener) graphsync.UnregisterHookFunc {
+	fgs.ReceiverNetworkErrorListener = listener
+	return func() {
+		fgs.ReceiverNetworkErrorListener = nil
 	}
 }
 


### PR DESCRIPTION
# Goals

Update to the latest go-graphsync which contains significant refactors and also additional features

# Implementation

- Update deps
- Update FakeGraphsync -- go-graphsync v0.6.0 contains a network ReceiveError listener as requested
- Update a couple integration tests that utilize some go-graphsync internals which have changed slightly.