### PR TITLE
Prevent concurrent restarts for same channel

### DIFF
--- a/transport/graphsync/channellocker.go
+++ b/transport/graphsync/channellocker.go
@@ -1,0 +1,85 @@
+package graphsync
+
+import (
+	"sync"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+)
+
+// Keeps track of the number of threads waiting on / holding the lock
+type channelLockerInfo struct {
+	lk       sync.Mutex
+	refCount int
+}
+
+// Keeps a map of channel ID -> lock
+type channelLocker struct {
+	mapLk        sync.Mutex
+	channelInfos map[datatransfer.ChannelID]*channelLockerInfo
+}
+
+func newChannelLocker() *channelLocker {
+	return &channelLocker{
+		channelInfos: make(map[datatransfer.ChannelID]*channelLockerInfo),
+	}
+}
+
+// lock takes an exclusive lock on the given channel ID.
+// It returns a function that should be called to unlock the channel ID.
+func (cl *channelLocker) lock(chid datatransfer.ChannelID) func() {
+	chanInfo := cl.lockForChannel(chid)
+
+	// Acquire the lock for the channel.
+	// Note: this will block until the current holder of the lock releases it.
+	chanInfo.lk.Lock()
+
+	// Lock acquired.
+	// Return a function that can be used to release the lock.
+	unlockChan := func() {
+		// Release the channel lock
+		chanInfo.lk.Unlock()
+
+		// Garbage collect the channel if there is no one else waiting on the
+		// lock
+		cl.unrefChannel(chid)
+	}
+
+	return unlockChan
+}
+
+func (cl *channelLocker) lockForChannel(chid datatransfer.ChannelID) *channelLockerInfo {
+	cl.mapLk.Lock()
+	defer cl.mapLk.Unlock()
+
+	// Get the info for the channel
+	chanInfo, ok := cl.channelInfos[chid]
+	if !ok {
+		// Create channel info it doesn't already isn't
+		chanInfo = &channelLockerInfo{}
+		cl.channelInfos[chid] = chanInfo
+	}
+
+	// Increment the count of threads waiting on / holding the lock
+	chanInfo.refCount++
+
+	return chanInfo
+}
+
+func (cl *channelLocker) unrefChannel(chid datatransfer.ChannelID) {
+	cl.mapLk.Lock()
+	defer cl.mapLk.Unlock()
+
+	chanInfo, ok := cl.channelInfos[chid]
+	if !ok {
+		// Sanity check - should never happen
+		return
+	}
+
+	// Decrement the count of threads waiting on / holding the lock
+	chanInfo.refCount--
+	if chanInfo.refCount == 0 {
+		// If there are no threads waiting on / holding lock, garbage
+		// collect the map entry
+		delete(cl.channelInfos, chid)
+	}
+}

--- a/transport/graphsync/channellocker_test.go
+++ b/transport/graphsync/channellocker_test.go
@@ -1,0 +1,113 @@
+package graphsync
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/require"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+)
+
+func TestChannelLocker(t *testing.T) {
+	chid1 := datatransfer.ChannelID{
+		Initiator: peer.ID("init"),
+		Responder: peer.ID("resp"),
+		ID:        1,
+	}
+	chid2 := datatransfer.ChannelID{
+		Initiator: peer.ID("init"),
+		Responder: peer.ID("resp"),
+		ID:        2,
+	}
+
+	t.Run("lock / unlock separate channels independently", func(t *testing.T) {
+		cl := newChannelLocker()
+		unlockCh1A := cl.lock(chid1)
+		unlockCh2A := cl.lock(chid2)
+		unlockCh1A()
+		unlockCh2A()
+	})
+
+	t.Run("lock after unlock", func(t *testing.T) {
+		cl := newChannelLocker()
+		unlockCh1A := cl.lock(chid1)
+		unlockCh1A()
+		unlockCh1B := cl.lock(chid1)
+		unlockCh1B()
+	})
+
+	t.Run("lock after two lock / unlocks", func(t *testing.T) {
+		cl := newChannelLocker()
+		unlockCh1A := cl.lock(chid1)
+		go func() {
+			unlockCh1B := cl.lock(chid1)
+			unlockCh1B()
+		}()
+		time.Sleep(10 * time.Millisecond)
+		unlockCh1A()
+
+		unlockCh1C := cl.lock(chid1)
+		unlockCh1C()
+	})
+
+	t.Run("lock waits for previous locks to unlock", func(t *testing.T) {
+		cl := newChannelLocker()
+
+		chan1BTakesLock := uint64(0)
+		unlockCh1A := cl.lock(chid1)
+		go func() {
+			cl.lock(chid1)
+			atomic.AddUint64(&chan1BTakesLock, 1)
+		}()
+
+		time.Sleep(10 * time.Millisecond)
+		locked := atomic.LoadUint64(&chan1BTakesLock)
+		if locked == 1 {
+			require.Fail(t, "expected second lock to wait for first to unlock")
+		}
+		unlockCh1A()
+
+		time.Sleep(10 * time.Millisecond)
+		locked = atomic.LoadUint64(&chan1BTakesLock)
+		if locked == 0 {
+			require.Fail(t, "expected second lock to complete after first unlocks")
+		}
+	})
+
+	t.Run("multiple concurrent lock / unlock", func(t *testing.T) {
+		cl := newChannelLocker()
+		numLocks := 100
+
+		var wg1 sync.WaitGroup
+		var wg2 sync.WaitGroup
+		//var unlocksCh2 []func()
+		var count1 uint64
+		var count2 uint64
+
+		doLocks := func(wg *sync.WaitGroup, count *uint64) {
+			for i := 0; i < numLocks; i++ {
+				go func() {
+					unlock := cl.lock(chid1)
+					atomic.AddUint64(count, 1)
+					time.Sleep(time.Millisecond)
+					unlock()
+					wg.Done()
+				}()
+			}
+		}
+
+		wg1.Add(numLocks)
+		go doLocks(&wg1, &count1)
+		wg2.Add(numLocks)
+		go doLocks(&wg2, &count2)
+
+		wg1.Wait()
+		wg2.Wait()
+		require.EqualValues(t, numLocks, atomic.LoadUint64(&count1))
+		require.EqualValues(t, numLocks, atomic.LoadUint64(&count2))
+	})
+}


### PR DESCRIPTION
This PR makes sure that when the data transfer is restarted for a pull request (retrieval), it cannot be interrupted by a second concurrent restart request for the same data transfer channel.