### PR TITLE
Fix pause on restart

### DIFF
--- a/channelmonitor/channelmonitor.go
+++ b/channelmonitor/channelmonitor.go
@@ -52,6 +52,8 @@ type Config struct {
 	// Max time to wait for the responder to send a Complete message once all
 	// data has been sent
 	CompleteTimeout time.Duration
+	// Called when a restart completes successfully
+	OnRestartComplete func(id datatransfer.ChannelID)
 }
 
 func NewMonitor(mgr monitorAPI, cfg *Config) *Monitor {
@@ -382,6 +384,9 @@ func (mc *monitoredChannel) restartChannel() {
 
 		if !restartAgain {
 			// No restart queued, we're done
+			if mc.cfg.OnRestartComplete != nil {
+				mc.cfg.OnRestartComplete(mc.chid)
+			}
 			return
 		}
 

--- a/impl/integration_test.go
+++ b/impl/integration_test.go
@@ -725,6 +725,7 @@ func TestAutoRestart(t *testing.T) {
 			// Set up
 			restartConf := ChannelRestartConfig(channelmonitor.Config{
 				AcceptTimeout:          100 * time.Millisecond,
+				RestartDebounce:        500 * time.Millisecond,
 				RestartBackoff:         500 * time.Millisecond,
 				MaxConsecutiveRestarts: 5,
 				RestartAckTimeout:      100 * time.Millisecond,


### PR DESCRIPTION
When there is a restart, and the data transfer hasn't yet started (eg because the data is still being unsealed) the new graphsync request should start off in the paused state