### PR TITLE
feat: use different extension names to fit multiple hooks data in same graphsync message

### DIFF
--- a/impl/integration_test.go
+++ b/impl/integration_test.go
@@ -3,6 +3,8 @@ package impl_test
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"io"
 	"math/rand"
 	"os"
 	"testing"
@@ -18,9 +20,13 @@ import (
 	gsnet "github.com/ipfs/go-graphsync/network"
 	"github.com/ipfs/go-graphsync/storeutil"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
+	chunker "github.com/ipfs/go-ipfs-chunker"
 	offline "github.com/ipfs/go-ipfs-exchange-offline"
+	files "github.com/ipfs/go-ipfs-files"
 	ipldformat "github.com/ipfs/go-ipld-format"
 	"github.com/ipfs/go-merkledag"
+	"github.com/ipfs/go-unixfs/importer/balanced"
+	ihelper "github.com/ipfs/go-unixfs/importer/helpers"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/libp2p/go-libp2p-core/host"
@@ -1069,6 +1075,7 @@ func TestSimulatedRetrievalFlow(t *testing.T) {
 				if channelState.Status() == datatransfer.Completed {
 					clientFinished <- struct{}{}
 				}
+				fmt.Println("=> CLIENT", datatransfer.Events[event.Code], datatransfer.Statuses[channelState.Status()])
 			}
 			dt2.SubscribeToEvents(clientSubscriber)
 			providerFinished := make(chan struct{}, 1)
@@ -1090,6 +1097,7 @@ func TestSimulatedRetrievalFlow(t *testing.T) {
 				if channelState.Status() == datatransfer.Completed {
 					providerFinished <- struct{}{}
 				}
+				fmt.Println("=> PROVIDER", datatransfer.Events[event.Code], datatransfer.Statuses[channelState.Status()])
 			}
 			dt1.SubscribeToEvents(providerSubscriber)
 			voucher := testutil.FakeDTType{Data: "applesauce"}
@@ -1711,6 +1719,163 @@ func TestRespondingToPullGraphsyncRequests(t *testing.T) {
 			data.test(t, gsData, tp2, link, id, gsr)
 		})
 	}
+}
+
+// Test the ability to attach data from multiple hooks in the same extension payload by using
+// different names
+func TestMultipleMessagesInExtension(t *testing.T) {
+	pausePoints := []uint64{1000, 3000, 6000, 10000, 15000}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+
+	gsData := testutil.NewGraphsyncTestingData(ctx, t, nil, nil)
+	host1 := gsData.Host1 // initiator, data sender
+
+	root, origBytes := LoadRandomData(ctx, t, gsData.DagService1)
+	gsData.OrigBytes = origBytes
+	rootCid := root.(cidlink.Link).Cid
+	tp1 := gsData.SetupGSTransportHost1()
+	tp2 := gsData.SetupGSTransportHost2()
+
+	dt1, err := NewDataTransfer(gsData.DtDs1, gsData.TempDir1, gsData.DtNet1, tp1)
+	require.NoError(t, err)
+	testutil.StartAndWaitForReady(ctx, t, dt1)
+
+	dt2, err := NewDataTransfer(gsData.DtDs2, gsData.TempDir2, gsData.DtNet2, tp2)
+	require.NoError(t, err)
+	testutil.StartAndWaitForReady(ctx, t, dt2)
+
+	var chid datatransfer.ChannelID
+	errChan := make(chan struct{}, 2)
+	clientPausePoint := 0
+
+	clientFinished := make(chan struct{}, 1)
+	clientGotResponse := make(chan struct{}, 1)
+
+	// The response voucher is the voucher returned by the request validator
+	respVoucher := testutil.NewFakeDTType()
+	encodedRVR, err := encoding.Encode(respVoucher)
+	require.NoError(t, err)
+
+	finalVoucherResult := testutil.NewFakeDTType()
+	encodedFVR, err := encoding.Encode(finalVoucherResult)
+	require.NoError(t, err)
+
+	dt2.SubscribeToEvents(func(event datatransfer.Event, channelState datatransfer.ChannelState) {
+		if event.Code == datatransfer.Error {
+			errChan <- struct{}{}
+		}
+		if event.Code == datatransfer.NewVoucherResult {
+			lastVoucherResult := channelState.LastVoucherResult()
+			encodedLVR, err := encoding.Encode(lastVoucherResult)
+			require.NoError(t, err)
+			if bytes.Equal(encodedLVR, encodedFVR) {
+				_ = dt2.SendVoucher(ctx, chid, testutil.NewFakeDTType())
+			}
+			if bytes.Equal(encodedLVR, encodedRVR) {
+				clientGotResponse <- struct{}{}
+			}
+		}
+		if event.Code == datatransfer.DataReceived &&
+			clientPausePoint < len(pausePoints) &&
+			channelState.Received() > pausePoints[clientPausePoint] {
+			_ = dt2.SendVoucher(ctx, chid, testutil.NewFakeDTType())
+			clientPausePoint++
+		}
+
+		if channelState.Status() == datatransfer.Completed {
+			clientFinished <- struct{}{}
+		}
+	})
+
+	providerFinished := make(chan struct{}, 1)
+	dt1.SubscribeToEvents(func(event datatransfer.Event, channelState datatransfer.ChannelState) {
+		if event.Code == datatransfer.Error {
+			errChan <- struct{}{}
+		}
+		if channelState.Status() == datatransfer.Completed {
+			providerFinished <- struct{}{}
+		}
+	})
+
+	voucher := testutil.FakeDTType{Data: "applesauce"}
+	sv := testutil.NewStubbedValidator()
+	require.NoError(t, dt1.RegisterVoucherType(&testutil.FakeDTType{}, sv))
+
+	srv := &retrievalRevalidator{
+		testutil.NewStubbedRevalidator(), 0, 0, pausePoints, finalVoucherResult,
+	}
+	srv.ExpectSuccessErrResume()
+	require.NoError(t, dt1.RegisterRevalidator(testutil.NewFakeDTType(), srv))
+
+	// Register our response voucher
+	require.NoError(t, dt2.RegisterVoucherResultType(respVoucher))
+	// Stub in the validator to make sure we receive that voucher
+	sv.StubResult(respVoucher)
+
+	chid, err = dt2.OpenPullDataChannel(ctx, host1.ID(), &voucher, rootCid, gsData.AllSelector)
+	require.NoError(t, err)
+
+	for clientGotResponse != nil || providerFinished != nil || clientFinished != nil {
+		select {
+		case <-ctx.Done():
+			t.Fatal("Did not complete successful data transfer")
+		case <-clientGotResponse:
+			clientGotResponse = nil
+		case <-providerFinished:
+			providerFinished = nil
+		case <-clientFinished:
+			clientFinished = nil
+		case <-errChan:
+			t.Fatal("received unexpected error")
+		}
+	}
+	sv.VerifyExpectations(t)
+	srv.VerifyExpectations(t)
+	gsData.VerifyFileTransferred(t, root, true)
+}
+
+func LoadRandomData(ctx context.Context, t *testing.T, dagService ipldformat.DAGService) (ipld.Link, []byte) {
+	tf, err := os.CreateTemp("", "data")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.Remove(tf.Name())
+	})
+
+	data := make([]byte, 256000)
+	rand.New(rand.NewSource(time.Now().UnixNano())).Read(data)
+	_, err = tf.Write(data)
+	require.NoError(t, err)
+
+	f, err := os.Open(tf.Name())
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	tr := io.TeeReader(f, &buf)
+	file := files.NewReaderFile(tr)
+
+	// import to UnixFS
+	bufferedDS := ipldformat.NewBufferedDAG(ctx, dagService)
+
+	params := ihelper.DagBuilderParams{
+		Maxlinks:   1024,
+		RawLeaves:  true,
+		CidBuilder: nil,
+		Dagserv:    bufferedDS,
+	}
+
+	db, err := params.New(chunker.NewSizeSplitter(file, int64(1<<10)))
+	require.NoError(t, err)
+
+	nd, err := balanced.Layout(db)
+	require.NoError(t, err)
+
+	err = bufferedDS.Commit()
+	require.NoError(t, err)
+
+	// save the original files bytes
+	return cidlink.Link{Cid: nd.Cid()}, buf.Bytes()
 }
 
 type receivedMessage struct {

--- a/impl/integration_test.go
+++ b/impl/integration_test.go
@@ -3,7 +3,6 @@ package impl_test
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"math/rand"
 	"os"
@@ -1075,7 +1074,6 @@ func TestSimulatedRetrievalFlow(t *testing.T) {
 				if channelState.Status() == datatransfer.Completed {
 					clientFinished <- struct{}{}
 				}
-				fmt.Println("=> CLIENT", datatransfer.Events[event.Code], datatransfer.Statuses[channelState.Status()])
 			}
 			dt2.SubscribeToEvents(clientSubscriber)
 			providerFinished := make(chan struct{}, 1)
@@ -1097,7 +1095,6 @@ func TestSimulatedRetrievalFlow(t *testing.T) {
 				if channelState.Status() == datatransfer.Completed {
 					providerFinished <- struct{}{}
 				}
-				fmt.Println("=> PROVIDER", datatransfer.Events[event.Code], datatransfer.Statuses[channelState.Status()])
 			}
 			dt1.SubscribeToEvents(providerSubscriber)
 			voucher := testutil.FakeDTType{Data: "applesauce"}

--- a/impl/integration_test.go
+++ b/impl/integration_test.go
@@ -1810,7 +1810,7 @@ func TestMultipleMessagesInExtension(t *testing.T) {
 	require.NoError(t, dt1.RegisterVoucherType(&testutil.FakeDTType{}, sv))
 	// Stub in the validator so it returns that exact voucher when calling ValidatePull
 	// this validator will not pause transfer when accepting a transfer and will start
-	// sending blocks immmediately
+	// sending blocks immediately
 	sv.StubResult(respVoucher)
 
 	srv := &retrievalRevalidator{

--- a/transport/graphsync/extension/gsextension.go
+++ b/transport/graphsync/extension/gsextension.go
@@ -77,19 +77,14 @@ func GetTransferData(extendedData GsExtended) (datatransfer.Message, error) {
 		ExtensionDataTransfer1_1,
 		ExtensionDataTransfer1_0,
 	}
-	i := 0
-	extName := extNames[i]
-	data, ok := extendedData.Extension(extName)
-	for !ok {
-		i++
-		if i == len(extNames) {
-			return nil, nil
+	for _, name := range extNames {
+		data, ok := extendedData.Extension(name)
+		if ok {
+			reader := bytes.NewReader(data)
+			return decoders[name](reader)
 		}
-		extName = extNames[i]
-		data, ok = extendedData.Extension(extName)
 	}
-	reader := bytes.NewReader(data)
-	return decoders[extName](reader)
+	return nil, nil
 }
 
 type decoder func(io.Reader) (datatransfer.Message, error)

--- a/transport/graphsync/extension/gsextension.go
+++ b/transport/graphsync/extension/gsextension.go
@@ -70,13 +70,7 @@ type GsExtended interface {
 //    * nil + nil if the extension is not found
 //    * nil + error if the extendedData fails to unmarshal
 //    * unmarshaled ExtensionDataTransferData + nil if all goes well
-func GetTransferData(extendedData GsExtended) (datatransfer.Message, error) {
-	extNames := []graphsync.ExtensionName{
-		ExtensionIncomingRequest1_1,
-		ExtensionOutgoingBlock1_1,
-		ExtensionDataTransfer1_1,
-		ExtensionDataTransfer1_0,
-	}
+func GetTransferData(extendedData GsExtended, extNames []graphsync.ExtensionName) (datatransfer.Message, error) {
 	for _, name := range extNames {
 		data, ok := extendedData.Extension(name)
 		if ok {

--- a/transport/graphsync/graphsync.go
+++ b/transport/graphsync/graphsync.go
@@ -440,6 +440,7 @@ func (t *Transport) gsOutgoingBlockHook(p peer.ID, request graphsync.RequestData
 
 	if msg != nil {
 		// gsOutgoingBlockHook uses a unique extension name so it can be attached with data from a different hook
+		// outgoingBlkExtensions also includes the default extension name so it remains compatible with all data-transfer protocol versions out there
 		extensions, err := extension.ToExtensionData(msg, t.outgoingBlkExtensions)
 		if err != nil {
 			hookActions.TerminateWithError(err)
@@ -507,6 +508,8 @@ func (t *Transport) gsReqRecdHook(p peer.ID, request graphsync.RequestData, hook
 	// If we need to send a response, add the response message as an extension
 	if responseMessage != nil {
 		// gsReqRecdHook uses a unique extension name so it can be attached with data from a different hook
+		// incomingReqExtensions also includes default extension name so it remains compatible with previous data-transfer
+		// protocol versions out there.
 		extensions, extensionErr := extension.ToExtensionData(responseMessage, t.incomingReqExtensions)
 		if extensionErr != nil {
 			hookActions.TerminateWithError(err)

--- a/transport/graphsync/graphsync.go
+++ b/transport/graphsync/graphsync.go
@@ -32,11 +32,22 @@ type graphsyncKey struct {
 	p         peer.ID
 }
 
-var defaultSupportedExtensions = []graphsync.ExtensionName{extension.ExtensionDataTransfer1_1, extension.ExtensionDataTransfer1_0}
+var defaultSupportedExtensions = []graphsync.ExtensionName{
+	extension.ExtensionDataTransfer1_1,
+	extension.ExtensionDataTransfer1_0,
+}
 
-var defaultIncomingReqExtensions = []graphsync.ExtensionName{extension.ExtensionIncomingRequest1_1}
+var defaultIncomingReqExtensions = []graphsync.ExtensionName{
+	extension.ExtensionIncomingRequest1_1,
+	extension.ExtensionDataTransfer1_1,
+	extension.ExtensionDataTransfer1_0,
+}
 
-var defaultOutgoingBlkExtensions = []graphsync.ExtensionName{extension.ExtensionOutgoingBlock1_1}
+var defaultOutgoingBlkExtensions = []graphsync.ExtensionName{
+	extension.ExtensionOutgoingBlock1_1,
+	extension.ExtensionDataTransfer1_1,
+	extension.ExtensionDataTransfer1_0,
+}
 
 // Option is an option for setting up the graphsync transport
 type Option func(*Transport)

--- a/transport/graphsync/graphsync.go
+++ b/transport/graphsync/graphsync.go
@@ -327,7 +327,7 @@ func (t *Transport) UseStore(channelID datatransfer.ChannelID, loader ipld.Loade
 
 // gsOutgoingRequestHook is called when a graphsync request is made
 func (t *Transport) gsOutgoingRequestHook(p peer.ID, request graphsync.RequestData, hookActions graphsync.OutgoingRequestHookActions) {
-	message, _ := extension.GetTransferData(request)
+	message, _ := extension.GetTransferData(request, t.supportedExtensions)
 
 	// extension not found; probably not our request.
 	if message == nil {
@@ -454,7 +454,8 @@ func (t *Transport) gsOutgoingBlockHook(p peer.ID, request graphsync.RequestData
 
 // gsReqRecdHook is called when graphsync receives an incoming request for data
 func (t *Transport) gsReqRecdHook(p peer.ID, request graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-	msg, err := extension.GetTransferData(request)
+	// if this is a push request the sender is us.
+	msg, err := extension.GetTransferData(request, t.supportedExtensions)
 	if err != nil {
 		hookActions.TerminateWithError(err)
 		return
@@ -617,7 +618,7 @@ func (t *Transport) gsRequestUpdatedHook(p peer.ID, request graphsync.RequestDat
 		return
 	}
 
-	responseMessage, err := t.processExtension(chid, update, p)
+	responseMessage, err := t.processExtension(chid, update, p, t.supportedExtensions)
 
 	if responseMessage != nil {
 		extensions, extensionErr := extension.ToExtensionData(responseMessage, t.supportedExtensions)
@@ -643,7 +644,7 @@ func (t *Transport) gsIncomingResponseHook(p peer.ID, response graphsync.Respons
 		return
 	}
 
-	responseMessage, err := t.processExtension(chid, response, p)
+	responseMessage, err := t.processExtension(chid, response, p, t.incomingReqExtensions)
 
 	if responseMessage != nil {
 		extensions, extensionErr := extension.ToExtensionData(responseMessage, t.supportedExtensions)
@@ -659,12 +660,23 @@ func (t *Transport) gsIncomingResponseHook(p peer.ID, response graphsync.Respons
 	if err != nil {
 		hookActions.TerminateWithError(err)
 	}
+
+	// In a case where the transfer sends blocks immediately this extension may contain both a
+	// response message and a revalidation request so we trigger OnResponseReceived again for this
+	// specific extension name
+	msg, err := extension.GetTransferData(response, []graphsync.ExtensionName{extension.ExtensionOutgoingBlock1_1})
+	if msg != nil {
+		err := t.events.OnResponseReceived(chid, msg.(datatransfer.Response))
+		if err != nil {
+			hookActions.TerminateWithError(err)
+		}
+	}
 }
 
-func (t *Transport) processExtension(chid datatransfer.ChannelID, gsMsg extension.GsExtended, p peer.ID) (datatransfer.Message, error) {
+func (t *Transport) processExtension(chid datatransfer.ChannelID, gsMsg extension.GsExtended, p peer.ID, exts []graphsync.ExtensionName) (datatransfer.Message, error) {
 
 	// if this is a push request the sender is us.
-	msg, err := extension.GetTransferData(gsMsg)
+	msg, err := extension.GetTransferData(gsMsg, exts)
 	if err != nil {
 		return nil, err
 	}

--- a/transport/graphsync/graphsync_test.go
+++ b/transport/graphsync/graphsync_test.go
@@ -227,9 +227,6 @@ func TestManager(t *testing.T) {
 			},
 		},
 		"incoming gs request with recognized dt request will validate gs request & send dt response": {
-			requestConfig: gsRequestConfig{
-				extName: extension.ExtensionIncomingRequest1_1,
-			},
 			action: func(gsData *harness) {
 				gsData.incomingRequestHook()
 			},
@@ -240,10 +237,10 @@ func TestManager(t *testing.T) {
 				require.Equal(t, 1, events.OnRequestReceivedCallCount)
 				require.Equal(t, 0, events.OnResponseReceivedCallCount)
 				require.Equal(t, events.RequestReceivedChannelID, datatransfer.ChannelID{ID: gsData.transferID, Responder: gsData.self, Initiator: gsData.other})
-				dtRequestData, _ := gsData.request.Extension(extension.ExtensionIncomingRequest1_1)
+				dtRequestData, _ := gsData.request.Extension(extension.ExtensionDataTransfer1_1)
 				assertDecodesToMessage(t, dtRequestData, events.RequestReceivedRequest)
 				require.True(t, gsData.incomingRequestHookActions.Validated)
-				assertHasExtensionMessage(t, extension.ExtensionIncomingRequest1_1, gsData.incomingRequestHookActions.SentExtensions, events.RequestReceivedResponse)
+				assertHasExtensionMessage(t, extension.ExtensionDataTransfer1_1, gsData.incomingRequestHookActions.SentExtensions, events.RequestReceivedResponse)
 				require.NoError(t, gsData.incomingRequestHookActions.TerminationError)
 			},
 		},
@@ -1182,7 +1179,6 @@ type gsRequestConfig struct {
 	dtExtensionMissing   bool
 	dtIsResponse         bool
 	dtExtensionMalformed bool
-	extName              graphsync.ExtensionName
 }
 
 func (grc *gsRequestConfig) makeRequest(t *testing.T, transferID datatransfer.TransferID, requestID graphsync.RequestID) graphsync.RequestData {
@@ -1191,11 +1187,7 @@ func (grc *gsRequestConfig) makeRequest(t *testing.T, transferID datatransfer.Tr
 		dtIsResponse:         grc.dtIsResponse,
 		dtExtensionMalformed: grc.dtExtensionMalformed,
 	}
-	extName := extension.ExtensionDataTransfer1_1
-	if grc.extName != "" {
-		extName = grc.extName
-	}
-	extensions := dtConfig.extensions(t, transferID, extName)
+	extensions := dtConfig.extensions(t, transferID, extension.ExtensionDataTransfer1_1)
 	return testutil.NewFakeRequest(requestID, extensions)
 }
 


### PR DESCRIPTION
As suggested by @hannahhoward, this PR uses different extension names for the income request and outgoing blocks so they can be included in the same extension message. Not sure how to handle the `SupportedExtensions` option in the transport constructor, this is rather hacky but it unblocks use cases in which request validation does not pause the manager for unsealing.