### PR TITLE
Remove CID lists

### DIFF
--- a/channelmonitor/channelmonitor_test.go
+++ b/channelmonitor/channelmonitor_test.go
@@ -611,3 +611,7 @@ func (m *mockChannelState) Stages() *datatransfer.ChannelStages {
 func (m *mockChannelState) ReceivedCids() []cid.Cid {
 	panic("implement me")
 }
+
+func (m *mockChannelState) ReceivedCidsLen() int {
+	panic("implement me")
+}

--- a/channels/channels_test.go
+++ b/channels/channels_test.go
@@ -179,7 +179,7 @@ func TestChannels(t *testing.T) {
 		state = checkEvent(ctx, t, received, datatransfer.DataReceived)
 		require.Equal(t, uint64(100), state.Received())
 		require.Equal(t, uint64(100), state.Sent())
-		require.Equal(t, []cid.Cid{cids[0], cids[1]}, state.ReceivedCids())
+		require.ElementsMatch(t, []cid.Cid{cids[0], cids[1]}, state.ReceivedCids())
 
 		isNew, err = channelList.DataSent(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[1], 25)
 		require.NoError(t, err)
@@ -187,7 +187,7 @@ func TestChannels(t *testing.T) {
 		state = checkEvent(ctx, t, received, datatransfer.DataSent)
 		require.Equal(t, uint64(100), state.Received())
 		require.Equal(t, uint64(100), state.Sent())
-		require.Equal(t, []cid.Cid{cids[0], cids[1]}, state.ReceivedCids())
+		require.ElementsMatch(t, []cid.Cid{cids[0], cids[1]}, state.ReceivedCids())
 
 		isNew, err = channelList.DataReceived(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[0], 50)
 		require.NoError(t, err)
@@ -195,7 +195,7 @@ func TestChannels(t *testing.T) {
 		state = checkEvent(ctx, t, received, datatransfer.DataReceived)
 		require.Equal(t, uint64(100), state.Received())
 		require.Equal(t, uint64(100), state.Sent())
-		require.Equal(t, []cid.Cid{cids[0], cids[1], cids[0]}, state.ReceivedCids())
+		require.ElementsMatch(t, []cid.Cid{cids[0], cids[1]}, state.ReceivedCids())
 	})
 
 	t.Run("pause/resume", func(t *testing.T) {
@@ -613,7 +613,10 @@ func TestMigrationsV1(t *testing.T) {
 		require.Equal(t, messages[i], channel.Message())
 		require.Equal(t, vouchers[i], channel.LastVoucher())
 		require.Equal(t, voucherResults[i], channel.LastVoucherResult())
-		require.Equal(t, receivedCids[i], channel.ReceivedCids())
+		// No longer relying on this migration to migrate CID lists as they
+		// have been deprecated since we moved to CID sets:
+		// https://github.com/filecoin-project/go-data-transfer/pull/217
+		//require.Equal(t, receivedCids[i], channel.ReceivedCids())
 	}
 }
 

--- a/cidlists/cidlists.go
+++ b/cidlists/cidlists.go
@@ -12,6 +12,7 @@ import (
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 )
 
+// Deprecated: CIDLists have now been replaced by CID sets (see cidsets directory).
 // CIDLists maintains files that contain a list of CIDs received for different data transfers
 type CIDLists interface {
 	CreateList(chid datatransfer.ChannelID, initalCids []cid.Cid) error

--- a/cidsets/cidsets_test.go
+++ b/cidsets/cidsets_test.go
@@ -18,30 +18,142 @@ func TestCIDSetManager(t *testing.T) {
 	setID1 := SetID("set1")
 	setID2 := SetID("set2")
 
+	// set1: +cid1
 	exists, err := mgr.InsertSetCID(setID1, cid1)
 	require.NoError(t, err)
 	require.False(t, exists)
 
+	// set1: +cid1 (again)
 	exists, err = mgr.InsertSetCID(setID1, cid1)
 	require.NoError(t, err)
 	require.True(t, exists)
 
+	// set2: +cid1
 	exists, err = mgr.InsertSetCID(setID2, cid1)
 	require.NoError(t, err)
 	require.False(t, exists)
 
+	// set2: +cid2 (again)
 	exists, err = mgr.InsertSetCID(setID2, cid1)
 	require.NoError(t, err)
 	require.True(t, exists)
 
+	// delete set1
 	err = mgr.DeleteSet(setID1)
 	require.NoError(t, err)
 
+	// set1: +cid1
 	exists, err = mgr.InsertSetCID(setID1, cid1)
 	require.NoError(t, err)
 	require.False(t, exists)
 
+	// set1: +cid1 (again)
 	exists, err = mgr.InsertSetCID(setID2, cid1)
 	require.NoError(t, err)
 	require.True(t, exists)
+}
+
+func TestCIDSetToArray(t *testing.T) {
+	cids := testutil.GenerateCids(2)
+	cid1 := cids[0]
+	cid2 := cids[1]
+
+	dstore := ds_sync.MutexWrap(ds.NewMapDatastore())
+	mgr := NewCIDSetManager(dstore)
+	setID1 := SetID("set1")
+
+	// Expect no items in set
+	len, err := mgr.SetLen(setID1)
+	require.NoError(t, err)
+	require.Equal(t, 0, len)
+
+	arr, err := mgr.SetToArray(setID1)
+	require.NoError(t, err)
+	require.Len(t, arr, 0)
+
+	// set1: +cid1
+	exists, err := mgr.InsertSetCID(setID1, cid1)
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	// Expect 1 cid in set
+	len, err = mgr.SetLen(setID1)
+	require.NoError(t, err)
+	require.Equal(t, 1, len)
+
+	arr, err = mgr.SetToArray(setID1)
+	require.NoError(t, err)
+	require.Len(t, arr, 1)
+	require.Equal(t, arr[0], cid1)
+
+	// set1: +cid1 (again)
+	exists, err = mgr.InsertSetCID(setID1, cid1)
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	// Expect 1 cid in set
+	len, err = mgr.SetLen(setID1)
+	require.NoError(t, err)
+	require.Equal(t, 1, len)
+
+	arr, err = mgr.SetToArray(setID1)
+	require.NoError(t, err)
+	require.Len(t, arr, 1)
+	require.Equal(t, arr[0], cid1)
+
+	// set1: +cid2
+	exists, err = mgr.InsertSetCID(setID1, cid2)
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	// Expect 2 cids in set
+	len, err = mgr.SetLen(setID1)
+	require.NoError(t, err)
+	require.Equal(t, 2, len)
+
+	arr, err = mgr.SetToArray(setID1)
+	require.NoError(t, err)
+	require.Len(t, arr, 2)
+	require.Contains(t, arr, cid1)
+	require.Contains(t, arr, cid2)
+
+	// Delete set1
+	err = mgr.DeleteSet(setID1)
+	require.NoError(t, err)
+
+	// Expect no items in set
+	len, err = mgr.SetLen(setID1)
+	require.NoError(t, err)
+	require.Equal(t, 0, len)
+
+	arr, err = mgr.SetToArray(setID1)
+	require.NoError(t, err)
+	require.Len(t, arr, 0)
+}
+
+// Add items to set then get the length (to make sure that internal caching
+// is working correctly)
+func TestCIDSetLenAfterInsert(t *testing.T) {
+	cids := testutil.GenerateCids(2)
+	cid1 := cids[0]
+	cid2 := cids[1]
+
+	dstore := ds_sync.MutexWrap(ds.NewMapDatastore())
+	mgr := NewCIDSetManager(dstore)
+	setID1 := SetID("set1")
+
+	// set1: +cid1
+	exists, err := mgr.InsertSetCID(setID1, cid1)
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	// set1: +cid2
+	exists, err = mgr.InsertSetCID(setID1, cid2)
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	// Expect 2 cids in set
+	len, err := mgr.SetLen(setID1)
+	require.NoError(t, err)
+	require.Equal(t, 2, len)
 }

--- a/impl/initiating_test.go
+++ b/impl/initiating_test.go
@@ -386,7 +386,7 @@ func TestDataTransferRestartInitiating(t *testing.T) {
 				require.Equal(t, openChannel.Selector, h.stor)
 				require.True(t, openChannel.Message.IsRequest())
 				// received cids should be a part of the channel req
-				require.Equal(t, []cid.Cid{testCids[0], testCids[1]}, openChannel.DoNotSendCids)
+				require.ElementsMatch(t, []cid.Cid{testCids[0], testCids[1]}, openChannel.DoNotSendCids)
 
 				receivedRequest, ok := openChannel.Message.(datatransfer.Request)
 				require.True(t, ok)

--- a/impl/responding_test.go
+++ b/impl/responding_test.go
@@ -673,7 +673,7 @@ func TestDataTransferRestartResponding(t *testing.T) {
 				require.Equal(t, openChannel.Root, cidlink.Link{Cid: h.baseCid})
 				require.Equal(t, openChannel.Selector, h.stor)
 				// assert do not send cids are sent
-				require.Equal(t, []cid.Cid{testCids[0], testCids[1]}, openChannel.DoNotSendCids)
+				require.ElementsMatch(t, []cid.Cid{testCids[0], testCids[1]}, openChannel.DoNotSendCids)
 				require.False(t, openChannel.Message.IsRequest())
 				response, ok := openChannel.Message.(datatransfer.Response)
 				require.True(t, ok)
@@ -884,7 +884,7 @@ func TestDataTransferRestartResponding(t *testing.T) {
 				require.Equal(t, openChannel.Selector, h.stor)
 				require.True(t, openChannel.Message.IsRequest())
 				// received cids should be a part of the channel req
-				require.Equal(t, []cid.Cid{testCids[0], testCids[1]}, openChannel.DoNotSendCids)
+				require.ElementsMatch(t, openChannel.DoNotSendCids, testCids)
 
 				// assert a restart request is in the channel
 				request, ok := openChannel.Message.(datatransfer.Request)

--- a/types.go
+++ b/types.go
@@ -132,6 +132,9 @@ type ChannelState interface {
 	// ReceivedCids returns the cids received so far on the channel
 	ReceivedCids() []cid.Cid
 
+	// ReceivedCidsLen returns the number of cids received so far on the channel
+	ReceivedCidsLen() int
+
 	// Queued returns the number of bytes read from the node and queued for sending
 	Queued() uint64
 


### PR DESCRIPTION
Supersedes https://github.com/filecoin-project/go-data-transfer/pull/216
Fixes https://github.com/filecoin-project/go-data-transfer/issues/178
Fixes immediate bottleneck in https://github.com/filecoin-project/go-data-transfer/issues/166 (but there is another bottleneck)

TODO:
- [x] Unit tests for new cid list methods
- [x] Figure out what to do about channel state migration at https://github.com/filecoin-project/go-data-transfer/blob/master/channels/internal/migrations/migrations.go#L67
_Resolution: deprecate CID lists and ignore migration - it's 7 months old so everyone should have migrated by now_
- [x] Benchmarking (see https://github.com/filecoin-project/go-data-transfer/issues/166)