### PR TITLE
Log closing of completion channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
       - when:
           condition: << parameters.linux >>
           steps:
-            - run: sudo apt-get update
+            - run: sudo apt-get update --allow-releaseinfo-change
             - run: sudo apt-get install ocl-icd-opencl-dev
   build-all:
 

--- a/transport/graphsync/graphsync.go
+++ b/transport/graphsync/graphsync.go
@@ -179,7 +179,10 @@ func (t *Transport) consumeResponses(responseChan <-chan graphsync.ResponseProgr
 // Read from the graphsync response and error channels until they are closed
 // or there is an error, then call the channel completed callback
 func (t *Transport) executeGsRequest(req *gsReq) {
-	defer req.onComplete()
+	defer func() {
+		log.Infow("gs request complete for channel", "chid", req.channelID)
+		req.onComplete()
+	}()
 
 	lastError := t.consumeResponses(req.responseChan, req.errChan)
 
@@ -885,6 +888,7 @@ func (c *dtChannel) open(ctx context.Context, chid datatransfer.ChannelID, dataS
 	// completes (or is cancelled)
 	completed := make(chan struct{})
 	onComplete := func() {
+		log.Infow("closing the completion ch for data-transfer channel", "chid", chid)
 		close(completed)
 	}
 	c.completed = completed


### PR DESCRIPTION
Log closing of the completion _channel_ of the data transfer channel when the corresponding Graphsync request completes.