### PR TITLE
Handle data-sent and data-queued events in the TransferFinished state

### DIFF
--- a/channels/channels_fsm.go
+++ b/channels/channels_fsm.go
@@ -60,17 +60,26 @@ var ChannelEvents = fsm.Events{
 			chst.AddLog("received data")
 			return nil
 		}),
-	fsm.Event(datatransfer.DataSent).FromMany(transferringStates...).ToNoChange().Action(func(chst *internal.ChannelState) error {
+
+	fsm.Event(datatransfer.DataSent).
+		FromMany(transferringStates...).ToNoChange().
+		From(datatransfer.TransferFinished).ToNoChange().
+		Action(func(chst *internal.ChannelState) error {
 		chst.AddLog("")
 		return nil
 	}),
+
 	fsm.Event(datatransfer.DataSentProgress).FromMany(transferringStates...).ToNoChange().
 		Action(func(chst *internal.ChannelState, delta uint64) error {
 			chst.Sent += delta
 			chst.AddLog("sending data")
 			return nil
 		}),
-	fsm.Event(datatransfer.DataQueued).FromMany(transferringStates...).ToNoChange().Action(func(chst *internal.ChannelState) error {
+
+	fsm.Event(datatransfer.DataQueued).
+		FromMany(transferringStates...).ToNoChange().
+		From(datatransfer.TransferFinished).ToNoChange().
+		Action(func(chst *internal.ChannelState) error {
 		chst.AddLog("")
 		return nil
 	}),

--- a/channels/channels_fsm.go
+++ b/channels/channels_fsm.go
@@ -65,9 +65,9 @@ var ChannelEvents = fsm.Events{
 		FromMany(transferringStates...).ToNoChange().
 		From(datatransfer.TransferFinished).ToNoChange().
 		Action(func(chst *internal.ChannelState) error {
-		chst.AddLog("")
-		return nil
-	}),
+			chst.AddLog("")
+			return nil
+		}),
 
 	fsm.Event(datatransfer.DataSentProgress).FromMany(transferringStates...).ToNoChange().
 		Action(func(chst *internal.ChannelState, delta uint64) error {
@@ -80,9 +80,9 @@ var ChannelEvents = fsm.Events{
 		FromMany(transferringStates...).ToNoChange().
 		From(datatransfer.TransferFinished).ToNoChange().
 		Action(func(chst *internal.ChannelState) error {
-		chst.AddLog("")
-		return nil
-	}),
+			chst.AddLog("")
+			return nil
+		}),
 	fsm.Event(datatransfer.DataQueuedProgress).FromMany(transferringStates...).ToNoChange().
 		Action(func(chst *internal.ChannelState, delta uint64) error {
 			chst.Queued += delta

--- a/channels/channels_test.go
+++ b/channels/channels_test.go
@@ -138,6 +138,39 @@ func TestChannels(t *testing.T) {
 		require.Equal(t, state.Status(), datatransfer.Ongoing)
 	})
 
+	t.Run("datasent/queued when transfer is already finished", func(t *testing.T) {
+		ds := dss.MutexWrap(datastore.NewMapDatastore())
+		dir := os.TempDir()
+		cidLists, err := cidlists.NewCIDLists(dir)
+		require.NoError(t, err)
+		channelList, err := channels.New(ds, cidLists, notifier, decoderByType, decoderByType, &fakeEnv{}, peers[0])
+		require.NoError(t, err)
+		err = channelList.Start(ctx)
+		require.NoError(t, err)
+
+		chid, err := channelList.CreateNew(peers[0], tid1, cids[0], selector, fv1, peers[0], peers[0], peers[1])
+		require.NoError(t, err)
+		checkEvent(ctx, t, received, datatransfer.Open)
+
+		// move the channel to `TransferFinished` state.
+		require.NoError(t, channelList.FinishTransfer(chid))
+		state := checkEvent(ctx, t, received, datatransfer.FinishTransfer)
+		require.Equal(t, datatransfer.TransferFinished, state.Status())
+
+		// send a data-sent event and ensure it's a no-op
+		_, err = channelList.DataSent(chid, cids[1], 1)
+		require.NoError(t, err)
+		state = checkEvent(ctx, t, received, datatransfer.DataSent)
+		require.Equal(t, datatransfer.TransferFinished, state.Status())
+
+
+		// send a data-queued event and ensure it's a no-op.
+		_, err = channelList.DataQueued(chid, cids[1], 1)
+		require.NoError(t, err)
+		state = checkEvent(ctx, t, received, datatransfer.DataQueued)
+		require.Equal(t, datatransfer.TransferFinished, state.Status())
+	})
+
 	t.Run("updating send/receive values", func(t *testing.T) {
 		ds := dss.MutexWrap(datastore.NewMapDatastore())
 		dir := os.TempDir()

--- a/channels/channels_test.go
+++ b/channels/channels_test.go
@@ -163,7 +163,6 @@ func TestChannels(t *testing.T) {
 		state = checkEvent(ctx, t, received, datatransfer.DataSent)
 		require.Equal(t, datatransfer.TransferFinished, state.Status())
 
-
 		// send a data-queued event and ensure it's a no-op.
 		_, err = channelList.DataQueued(chid, cids[1], 1)
 		require.NoError(t, err)


### PR DESCRIPTION
Closes #234 .

- After a data-transfer restart, Graphsync can still call the `OnDataSent` hook for blocks that have already been sent which in turn will fire the `DataSent` data-transfer event. The same applies to the `DataQueued` event.
- To ensure we don't double count data sent, we introduced a `DataSentProgress` and a `DataQueuedProgress` events a while ago in https://github.com/filecoin-project/go-data-transfer/pull/185.  These events are only emitted the first time we send a block to a remote peer.
- Thus, if a data-transfer restarts after entering the `TransferFinished` state, we can still receive `DataSent` and `DataQueued` events for  blocks that have already been sent. We need to handle these events gracefully in the `TransferFinished` state. We do see a LOT of restarts in Estaury's logs for data-transfer across the board. See attached.
- Note however, that we should NOT see the `DataSentProgress` and a `DataQueuedProgress`  events in the `TransferFinished` state and this is confirmed by Estuary's logs.


**_Note:_** I don't think this error actually causes storage deals to fail but still nice to fix to clean up the logs.

[shuttle-logs-bad-tx3 (1).gz](https://github.com/filecoin-project/go-data-transfer/files/7005749/shuttle-logs-bad-tx3.1.gz)
