### PR TITLE
Send data-transfer protocol cancel's message async to the remote peer

### DIFF
--- a/impl/initiating_test.go
+++ b/impl/initiating_test.go
@@ -213,7 +213,10 @@ func TestDataTransferInitiating(t *testing.T) {
 				require.NoError(t, err)
 				require.Len(t, h.transport.ClosedChannels, 1)
 				require.Equal(t, h.transport.ClosedChannels[0], channelID)
-				require.Len(t, h.network.SentMessages, 2)
+
+				require.Eventually(t, func() bool {
+					return len(h.network.SentMessages) == 2
+				}, 5*time.Second, 200*time.Millisecond)
 				cancelMessage := h.network.SentMessages[1].Message
 				require.False(t, cancelMessage.IsUpdate())
 				require.False(t, cancelMessage.IsPaused())
@@ -266,7 +269,11 @@ func TestDataTransferInitiating(t *testing.T) {
 				require.NoError(t, err)
 				require.Len(t, h.transport.ClosedChannels, 1)
 				require.Equal(t, h.transport.ClosedChannels[0], channelID)
-				require.Len(t, h.network.SentMessages, 1)
+
+				require.Eventually(t, func() bool {
+					return len(h.network.SentMessages) == 1
+				}, 5*time.Second, 200*time.Millisecond)
+
 				cancelMessage := h.network.SentMessages[0].Message
 				require.False(t, cancelMessage.IsUpdate())
 				require.False(t, cancelMessage.IsPaused())


### PR DESCRIPTION
We saw a problem with Dealbot deals where it got hung on deal transferring state because the Miner had manually cancelled the request. Turns out that the Miner cancels weren't getting sent to the client because the timed context we use in Lotus wasn't giving enough time to the cancellation messages for them to go through as it only uses uses a timeout of 5 seconds for the entire cancel graphsync req -> open data-transfer stream -> write cancel message to the data-transfer stream thing.


```
2021-08-26T13:54:15.307Z	WARN	rpc	go-jsonrpc@v0.1.4-0.20210217175800-45ea43ac2bec/handler.go:279	
error in RPC call to 'Filecoin.MarketCancelDataTransfer': unable to send cancel message for 
channel 
12D3KooWGBWx9gyUFTVQcKMTenQMSyE2ad9m7c9fpjS4NMjoDien-
12D3KooWSsaFCtzDJUEhLQYDdwoFtdCMqqfk562UMvccFz12kYxU-1629767771563307811 
to peer 12D3KooWSsaFCtzDJUEhLQYDdwoFtdCMqqfk562UMvccFz12kYxU: context canceled
```

I think a good way to do this to send the data-transfer cancel message to the remote peer async so callers don't need to block on it for a good amount of time.

