### PR TITLE
remove libp2p protocol cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/libp2p/go-libp2p v0.13.0
 	github.com/libp2p/go-libp2p-core v0.8.5
 	github.com/libp2p/go-libp2p-record v0.1.1 // indirect
-	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/stretchr/testify v1.6.1
 	github.com/whyrusleeping/cbor-gen v0.0.0-20210219115102-f37d292932f2
 	go.uber.org/atomic v1.6.0

--- a/message.go
+++ b/message.go
@@ -16,7 +16,7 @@ var (
 	// version of data-transfer (supports do-not-send-first-blocks extension)
 	ProtocolDataTransfer1_2 protocol.ID = "/fil/datatransfer/1.2.0"
 
-	// ProtocolDataTransfer1_2 is the protocol identifier for the version
+	// ProtocolDataTransfer1_1 is the protocol identifier for the version
 	// of data-transfer that supports the do-not-send-cids extension
 	// (but not the do-not-send-first-blocks extension)
 	ProtocolDataTransfer1_1 protocol.ID = "/fil/datatransfer/1.1.0"


### PR DESCRIPTION
libp2p has its own protocol cache, so there's no need to keep on external to libp2p