### PR TITLE
Demonstrate no monitoring after restart

### DIFF
--- a/channelmonitor/channelmonitor.go
+++ b/channelmonitor/channelmonitor.go
@@ -119,6 +119,19 @@ func (m *Monitor) addChannel(chid datatransfer.ChannelID, isPush bool) *monitore
 	return mpc
 }
 
+// IsChannelMonitored returns true if the given channel ID is monitored
+func (m *Monitor) IsChannelMonitored(chid datatransfer.ChannelID) bool {
+	if !m.enabled() {
+		return false
+	}
+
+	m.lk.Lock()
+	defer m.lk.Unlock()
+
+	_, ok := m.channels[chid]
+	return ok
+}
+
 func (m *Monitor) Shutdown() {
 	// Cancel the context for the Monitor
 	m.stop()

--- a/impl/impl.go
+++ b/impl/impl.go
@@ -125,6 +125,10 @@ func NewDataTransfer(ds datastore.Batching, cidListsDir string, dataTransferNetw
 	return m, nil
 }
 
+func (m *manager) IsChannelMonitored(chid datatransfer.ChannelID) bool {
+	return m.channelMonitor.IsChannelMonitored(chid)
+}
+
 func (m *manager) voucherDecoder(voucherType datatransfer.TypeIdentifier) (encoding.Decoder, bool) {
 	decoder, has := m.validatedTypes.Decoder(voucherType)
 	if !has {

--- a/manager.go
+++ b/manager.go
@@ -132,6 +132,8 @@ type Manager interface {
 	// get all in progress transfers
 	InProgressChannels(ctx context.Context) (map[ChannelID]ChannelState, error)
 
+	IsChannelMonitored(chid ChannelID) bool
+
 	// RestartDataTransferChannel restarts an existing data transfer channel
 	RestartDataTransferChannel(ctx context.Context, chid ChannelID) error
 }


### PR DESCRIPTION
# What

When a new instance of go-data-transfer is constructed, and RestartDataTransferChannel is called, no channel monitoring is setup, meaning if the request stalls or errors, it will simply stay stalled.

# Demonstration

This is a bit of a contrive example (contains some functions you probably don't want to expose the monitoring status to the public)

Essentially this PR:
- Enables Channel Monitoring in the restart integration tests
- Uses some additional functions to log the channel monitoring status on each new DataSent call

Result:
```
go test --run=^TestRestartPush/Restart_peer_create_push -v ./impl
```

```
=== RUN   TestRestartPush
=== RUN   TestRestartPush/Restart_peer_create_push
    restart_integration_test.go:500: peer1 is 13fBgT2iW
    restart_integration_test.go:501: peer2 is 13kJcDpop
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:191: peers unlinked and disconnected, total increments received till now: 20
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:136: Send Channel is monitored
    restart_integration_test.go:223: request was not completed after disconnect
    restart_integration_test.go:232: peers have been connected and datatransfer has restarted
    restart_integration_test.go:181: got restart event for peer 13kJcDpop
    restart_integration_test.go:181: got restart event for peer 13fBgT2iW
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:204: peer 13kJcDpop completed
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:138: Send Channel is NOT monitored
    restart_integration_test.go:204: peer 13fBgT2iW completed
--- PASS: TestRestartPush (2.17s)
    --- PASS: TestRestartPush/Restart_peer_create_push (2.17s)
PASS
ok  	github.com/filecoin-project/go-data-transfer/impl	2.640s
```