### PR TITLE
Removing CID Lists part one: unblocking technical obstacles

### DIFF
--- a/channelmonitor/channelmonitor_test.go
+++ b/channelmonitor/channelmonitor_test.go
@@ -625,3 +625,11 @@ func (m *mockChannelState) ReceivedCidsTotal() int64 {
 func (m *mockChannelState) MissingCids() []cid.Cid {
 	panic("implement me")
 }
+
+func (m *mockChannelState) QueuedCidsTotal() int64 {
+	panic("implement me")
+}
+
+func (m *mockChannelState) SentCidsTotal() int64 {
+	panic("implement me")
+}

--- a/channels/block_index_cache.go
+++ b/channels/block_index_cache.go
@@ -1,0 +1,59 @@
+package channels
+
+import (
+	"sync"
+	"sync/atomic"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+)
+
+type readOriginalFn func(datatransfer.ChannelID) (int64, error)
+
+type blockIndexKey struct {
+	evt  datatransfer.EventCode
+	chid datatransfer.ChannelID
+}
+type blockIndexCache struct {
+	lk     sync.RWMutex
+	values map[blockIndexKey]*int64
+}
+
+func newBlockIndexCache() *blockIndexCache {
+	return &blockIndexCache{
+		values: make(map[blockIndexKey]*int64),
+	}
+}
+
+func (bic *blockIndexCache) getValue(evt datatransfer.EventCode, chid datatransfer.ChannelID, readFromOriginal readOriginalFn) (*int64, error) {
+	idxKey := blockIndexKey{evt, chid}
+	bic.lk.RLock()
+	value := bic.values[idxKey]
+	bic.lk.RUnlock()
+	if value != nil {
+		return value, nil
+	}
+	bic.lk.Lock()
+	defer bic.lk.Unlock()
+	value = bic.values[idxKey]
+	if value != nil {
+		return value, nil
+	}
+	newValue, err := readFromOriginal(chid)
+	if err != nil {
+		return nil, err
+	}
+	bic.values[idxKey] = &newValue
+	return &newValue, nil
+}
+
+func (bic *blockIndexCache) updateIfGreater(evt datatransfer.EventCode, chid datatransfer.ChannelID, newIndex int64, readFromOriginal readOriginalFn) (bool, error) {
+	value, err := bic.getValue(evt, chid, readFromOriginal)
+	if err != nil {
+		return false, nil
+	}
+	currentIndex := atomic.LoadInt64(value)
+	if newIndex <= currentIndex {
+		return false, nil
+	}
+	return atomic.CompareAndSwapInt64(value, currentIndex, newIndex), nil
+}

--- a/channels/channel_state.go
+++ b/channels/channel_state.go
@@ -43,6 +43,12 @@ type channelState struct {
 	// number of blocks that have been received, including blocks that are
 	// present in more than one place in the DAG
 	receivedBlocksTotal int64
+	// Number of blocks that have been queued, including blocks that are
+	// present in more than one place in the DAG
+	queuedBlocksTotal int64
+	// Number of blocks that have been sent, including blocks that are
+	// present in more than one place in the DAG
+	sentBlocksTotal int64
 	// more informative status on a channel
 	message string
 	// additional vouchers
@@ -126,6 +132,18 @@ func (c channelState) ReceivedCidsLen() int {
 // on the channel - note that a block can exist in more than one place in the DAG
 func (c channelState) ReceivedCidsTotal() int64 {
 	return c.receivedBlocksTotal
+}
+
+// QueuedCidsTotal returns the number of (non-unique) cids queued so far
+// on the channel - note that a block can exist in more than one place in the DAG
+func (c channelState) QueuedCidsTotal() int64 {
+	return c.queuedBlocksTotal
+}
+
+// SentCidsTotal returns the number of (non-unique) cids sent so far
+// on the channel - note that a block can exist in more than one place in the DAG
+func (c channelState) SentCidsTotal() int64 {
+	return c.sentBlocksTotal
 }
 
 // Sender returns the peer id for the node that is sending data
@@ -230,6 +248,8 @@ func fromInternalChannelState(c internal.ChannelState, voucherDecoder DecoderByT
 		sent:                 c.Sent,
 		received:             c.Received,
 		receivedBlocksTotal:  c.ReceivedBlocksTotal,
+		queuedBlocksTotal:    c.QueuedBlocksTotal,
+		sentBlocksTotal:      c.SentBlocksTotal,
 		message:              c.Message,
 		vouchers:             c.Vouchers,
 		voucherResults:       c.VoucherResults,

--- a/channels/channels_fsm.go
+++ b/channels/channels_fsm.go
@@ -79,14 +79,19 @@ var ChannelEvents = fsm.Events{
 	fsm.Event(datatransfer.DataSent).
 		FromMany(transferringStates...).ToNoChange().
 		From(datatransfer.TransferFinished).ToNoChange().
-		Action(func(chst *internal.ChannelState) error {
+		Action(func(chst *internal.ChannelState, sentBlocksTotal int64) error {
+			if sentBlocksTotal > chst.SentBlocksTotal {
+				chst.SentBlocksTotal = sentBlocksTotal
+			}
 			chst.AddLog("")
 			return nil
 		}),
 
 	fsm.Event(datatransfer.DataSentProgress).FromMany(transferringStates...).ToNoChange().
-		Action(func(chst *internal.ChannelState, delta uint64) error {
-			chst.Sent += delta
+		Action(func(chst *internal.ChannelState, sentBlocksTotal int64, delta uint64) error {
+			if sentBlocksTotal > chst.SentBlocksTotal {
+				chst.Sent += delta
+			}
 			chst.AddLog("sending data")
 			return nil
 		}),
@@ -94,13 +99,18 @@ var ChannelEvents = fsm.Events{
 	fsm.Event(datatransfer.DataQueued).
 		FromMany(transferringStates...).ToNoChange().
 		From(datatransfer.TransferFinished).ToNoChange().
-		Action(func(chst *internal.ChannelState) error {
+		Action(func(chst *internal.ChannelState, queuedBlocksTotal int64) error {
+			if queuedBlocksTotal > chst.QueuedBlocksTotal {
+				chst.QueuedBlocksTotal = queuedBlocksTotal
+			}
 			chst.AddLog("")
 			return nil
 		}),
 	fsm.Event(datatransfer.DataQueuedProgress).FromMany(transferringStates...).ToNoChange().
-		Action(func(chst *internal.ChannelState, delta uint64) error {
-			chst.Queued += delta
+		Action(func(chst *internal.ChannelState, queuedBlocksTotal int64, delta uint64) error {
+			if queuedBlocksTotal > chst.QueuedBlocksTotal {
+				chst.Queued += delta
+			}
 			chst.AddLog("")
 			return nil
 		}),

--- a/channels/channels_fsm.go
+++ b/channels/channels_fsm.go
@@ -88,10 +88,8 @@ var ChannelEvents = fsm.Events{
 		}),
 
 	fsm.Event(datatransfer.DataSentProgress).FromMany(transferringStates...).ToNoChange().
-		Action(func(chst *internal.ChannelState, sentBlocksTotal int64, delta uint64) error {
-			if sentBlocksTotal > chst.SentBlocksTotal {
-				chst.Sent += delta
-			}
+		Action(func(chst *internal.ChannelState, delta uint64) error {
+			chst.Sent += delta
 			chst.AddLog("sending data")
 			return nil
 		}),
@@ -107,10 +105,8 @@ var ChannelEvents = fsm.Events{
 			return nil
 		}),
 	fsm.Event(datatransfer.DataQueuedProgress).FromMany(transferringStates...).ToNoChange().
-		Action(func(chst *internal.ChannelState, queuedBlocksTotal int64, delta uint64) error {
-			if queuedBlocksTotal > chst.QueuedBlocksTotal {
-				chst.Queued += delta
-			}
+		Action(func(chst *internal.ChannelState, delta uint64) error {
+			chst.Queued += delta
 			chst.AddLog("")
 			return nil
 		}),

--- a/channels/channels_test.go
+++ b/channels/channels_test.go
@@ -158,13 +158,13 @@ func TestChannels(t *testing.T) {
 		require.Equal(t, datatransfer.TransferFinished, state.Status())
 
 		// send a data-sent event and ensure it's a no-op
-		_, err = channelList.DataSent(chid, cids[1], 1)
+		err = channelList.DataSent(chid, cids[1], 1, 1, true)
 		require.NoError(t, err)
 		state = checkEvent(ctx, t, received, datatransfer.DataSent)
 		require.Equal(t, datatransfer.TransferFinished, state.Status())
 
 		// send a data-queued event and ensure it's a no-op.
-		_, err = channelList.DataQueued(chid, cids[1], 1)
+		_, err = channelList.DataQueued(chid, cids[1], 1, 1, true)
 		require.NoError(t, err)
 		state = checkEvent(ctx, t, received, datatransfer.DataQueued)
 		require.Equal(t, datatransfer.TransferFinished, state.Status())
@@ -197,10 +197,9 @@ func TestChannels(t *testing.T) {
 		require.Equal(t, uint64(0), state.Sent())
 		require.Equal(t, []cid.Cid{cids[0]}, state.ReceivedCids())
 
-		isNew, err = channelList.DataSent(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[1], 100)
+		err = channelList.DataSent(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[1], 100, 1, true)
 		require.NoError(t, err)
 		_ = checkEvent(ctx, t, received, datatransfer.DataSentProgress)
-		require.True(t, isNew)
 		state = checkEvent(ctx, t, received, datatransfer.DataSent)
 		require.Equal(t, uint64(50), state.Received())
 		require.Equal(t, uint64(100), state.Sent())
@@ -210,10 +209,9 @@ func TestChannels(t *testing.T) {
 		isNew, err = channelList.DataReceived(datatransfer.ChannelID{Initiator: peers[1], Responder: peers[0], ID: tid1}, cids[1], 200, 2)
 		require.True(t, xerrors.As(err, new(*channels.ErrNotFound)))
 		require.False(t, isNew)
-		isNew, err = channelList.DataSent(datatransfer.ChannelID{Initiator: peers[1], Responder: peers[0], ID: tid1}, cids[1], 200)
+		err = channelList.DataSent(datatransfer.ChannelID{Initiator: peers[1], Responder: peers[0], ID: tid1}, cids[1], 200, 2, false)
 		require.True(t, xerrors.As(err, new(*channels.ErrNotFound)))
 		require.Equal(t, []cid.Cid{cids[0]}, state.ReceivedCids())
-		require.False(t, isNew)
 
 		isNew, err = channelList.DataReceived(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[1], 50, 2)
 		require.NoError(t, err)
@@ -224,9 +222,8 @@ func TestChannels(t *testing.T) {
 		require.Equal(t, uint64(100), state.Sent())
 		require.ElementsMatch(t, []cid.Cid{cids[0], cids[1]}, state.ReceivedCids())
 
-		isNew, err = channelList.DataSent(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[1], 25)
+		err = channelList.DataSent(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[1], 25, 2, false)
 		require.NoError(t, err)
-		require.False(t, isNew)
 		state = checkEvent(ctx, t, received, datatransfer.DataSent)
 		require.Equal(t, uint64(100), state.Received())
 		require.Equal(t, uint64(100), state.Sent())

--- a/channels/channels_test.go
+++ b/channels/channels_test.go
@@ -158,7 +158,7 @@ func TestChannels(t *testing.T) {
 		require.Equal(t, datatransfer.TransferFinished, state.Status())
 
 		// send a data-sent event and ensure it's a no-op
-		err = channelList.DataSent(chid, cids[1], 1, 1, true)
+		_, err = channelList.DataSent(chid, cids[1], 1, 1, true)
 		require.NoError(t, err)
 		state = checkEvent(ctx, t, received, datatransfer.DataSent)
 		require.Equal(t, datatransfer.TransferFinished, state.Status())
@@ -188,7 +188,7 @@ func TestChannels(t *testing.T) {
 		require.Equal(t, uint64(0), state.Sent())
 		require.Empty(t, state.ReceivedCids())
 
-		isNew, err := channelList.DataReceived(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[0], 50, 1)
+		isNew, err := channelList.DataReceived(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[0], 50, 1, true)
 		require.NoError(t, err)
 		_ = checkEvent(ctx, t, received, datatransfer.DataReceivedProgress)
 		require.True(t, isNew)
@@ -197,23 +197,33 @@ func TestChannels(t *testing.T) {
 		require.Equal(t, uint64(0), state.Sent())
 		require.Equal(t, []cid.Cid{cids[0]}, state.ReceivedCids())
 
-		err = channelList.DataSent(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[1], 100, 1, true)
+		isNew, err = channelList.DataSent(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[1], 100, 1, true)
 		require.NoError(t, err)
 		_ = checkEvent(ctx, t, received, datatransfer.DataSentProgress)
+		require.True(t, isNew)
 		state = checkEvent(ctx, t, received, datatransfer.DataSent)
 		require.Equal(t, uint64(50), state.Received())
 		require.Equal(t, uint64(100), state.Sent())
 		require.Equal(t, []cid.Cid{cids[0]}, state.ReceivedCids())
 
+		// send block again has no effect
+		isNew, err = channelList.DataSent(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[1], 100, 1, true)
+		require.NoError(t, err)
+		require.False(t, isNew)
+		state = checkEvent(ctx, t, received, datatransfer.DataSent)
+		require.Equal(t, uint64(50), state.Received())
+		require.Equal(t, uint64(100), state.Sent())
+
 		// errors if channel does not exist
-		isNew, err = channelList.DataReceived(datatransfer.ChannelID{Initiator: peers[1], Responder: peers[0], ID: tid1}, cids[1], 200, 2)
+		isNew, err = channelList.DataReceived(datatransfer.ChannelID{Initiator: peers[1], Responder: peers[0], ID: tid1}, cids[1], 200, 2, true)
 		require.True(t, xerrors.As(err, new(*channels.ErrNotFound)))
 		require.False(t, isNew)
-		err = channelList.DataSent(datatransfer.ChannelID{Initiator: peers[1], Responder: peers[0], ID: tid1}, cids[1], 200, 2, false)
+		isNew, err = channelList.DataSent(datatransfer.ChannelID{Initiator: peers[1], Responder: peers[0], ID: tid1}, cids[1], 200, 2, true)
 		require.True(t, xerrors.As(err, new(*channels.ErrNotFound)))
 		require.Equal(t, []cid.Cid{cids[0]}, state.ReceivedCids())
+		require.False(t, isNew)
 
-		isNew, err = channelList.DataReceived(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[1], 50, 2)
+		isNew, err = channelList.DataReceived(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[1], 50, 2, true)
 		require.NoError(t, err)
 		_ = checkEvent(ctx, t, received, datatransfer.DataReceivedProgress)
 		require.True(t, isNew)
@@ -222,19 +232,21 @@ func TestChannels(t *testing.T) {
 		require.Equal(t, uint64(100), state.Sent())
 		require.ElementsMatch(t, []cid.Cid{cids[0], cids[1]}, state.ReceivedCids())
 
-		err = channelList.DataSent(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[1], 25, 2, false)
+		isNew, err = channelList.DataSent(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[1], 25, 2, false)
 		require.NoError(t, err)
+		require.False(t, isNew)
 		state = checkEvent(ctx, t, received, datatransfer.DataSent)
 		require.Equal(t, uint64(100), state.Received())
 		require.Equal(t, uint64(100), state.Sent())
 		require.ElementsMatch(t, []cid.Cid{cids[0], cids[1]}, state.ReceivedCids())
 
-		isNew, err = channelList.DataReceived(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[0], 50, 3)
+		isNew, err = channelList.DataReceived(datatransfer.ChannelID{Initiator: peers[0], Responder: peers[1], ID: tid1}, cids[0], 50, 3, false)
 		require.NoError(t, err)
 		require.False(t, isNew)
 		state = checkEvent(ctx, t, received, datatransfer.DataReceived)
 		require.Equal(t, uint64(100), state.Received())
 		require.Equal(t, uint64(100), state.Sent())
+
 		require.ElementsMatch(t, []cid.Cid{cids[0], cids[1]}, state.ReceivedCids())
 	})
 

--- a/channels/internal/internalchannel.go
+++ b/channels/internal/internalchannel.go
@@ -63,7 +63,12 @@ type ChannelState struct {
 	// Number of blocks that have been received, including blocks that are
 	// present in more than one place in the DAG
 	ReceivedBlocksTotal int64
-
+	// Number of blocks that have been queued, including blocks that are
+	// present in more than one place in the DAG
+	QueuedBlocksTotal int64
+	// Number of blocks that have been sent, including blocks that are
+	// present in more than one place in the DAG
+	SentBlocksTotal int64
 	// Stages traces the execution fo a data transfer.
 	//
 	// EXPERIMENTAL; subject to change.

--- a/channels/internal/internalchannel_cbor_gen.go
+++ b/channels/internal/internalchannel_cbor_gen.go
@@ -23,7 +23,7 @@ func (t *ChannelState) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{179}); err != nil {
+	if _, err := w.Write([]byte{181}); err != nil {
 		return err
 	}
 
@@ -363,6 +363,50 @@ func (t *ChannelState) MarshalCBOR(w io.Writer) error {
 		}
 	} else {
 		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.ReceivedBlocksTotal-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.QueuedBlocksTotal (int64) (int64)
+	if len("QueuedBlocksTotal") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"QueuedBlocksTotal\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("QueuedBlocksTotal"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("QueuedBlocksTotal")); err != nil {
+		return err
+	}
+
+	if t.QueuedBlocksTotal >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.QueuedBlocksTotal)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.QueuedBlocksTotal-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.SentBlocksTotal (int64) (int64)
+	if len("SentBlocksTotal") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"SentBlocksTotal\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("SentBlocksTotal"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("SentBlocksTotal")); err != nil {
+		return err
+	}
+
+	if t.SentBlocksTotal >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.SentBlocksTotal)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.SentBlocksTotal-1)); err != nil {
 			return err
 		}
 	}
@@ -708,6 +752,58 @@ func (t *ChannelState) UnmarshalCBOR(r io.Reader) error {
 				}
 
 				t.ReceivedBlocksTotal = int64(extraI)
+			}
+			// t.QueuedBlocksTotal (int64) (int64)
+		case "QueuedBlocksTotal":
+			{
+				maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+				var extraI int64
+				if err != nil {
+					return err
+				}
+				switch maj {
+				case cbg.MajUnsignedInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 positive overflow")
+					}
+				case cbg.MajNegativeInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 negative oveflow")
+					}
+					extraI = -1 - extraI
+				default:
+					return fmt.Errorf("wrong type for int64 field: %d", maj)
+				}
+
+				t.QueuedBlocksTotal = int64(extraI)
+			}
+			// t.SentBlocksTotal (int64) (int64)
+		case "SentBlocksTotal":
+			{
+				maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+				var extraI int64
+				if err != nil {
+					return err
+				}
+				switch maj {
+				case cbg.MajUnsignedInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 positive overflow")
+					}
+				case cbg.MajNegativeInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 negative oveflow")
+					}
+					extraI = -1 - extraI
+				default:
+					return fmt.Errorf("wrong type for int64 field: %d", maj)
+				}
+
+				t.SentBlocksTotal = int64(extraI)
 			}
 			// t.Stages (datatransfer.ChannelStages) (struct)
 		case "Stages":

--- a/impl/events.go
+++ b/impl/events.go
@@ -97,7 +97,7 @@ func (m *manager) OnDataReceived(chid datatransfer.ChannelID, link ipld.Link, si
 // up some data to be sent to the requester.
 // It fires an event on the channel, updating the sum of queued data and calls
 // revalidators so they can pause / resume or send a message over the transport.
-func (m *manager) OnDataQueued(chid datatransfer.ChannelID, link ipld.Link, size uint64) (datatransfer.Message, error) {
+func (m *manager) OnDataQueued(chid datatransfer.ChannelID, link ipld.Link, size uint64, index int64, unique bool) (datatransfer.Message, error) {
 	// The transport layer reports that some data has been queued up to be sent
 	// to the requester, so fire a DataQueued event on the channels state
 	// machine.
@@ -110,7 +110,7 @@ func (m *manager) OnDataQueued(chid datatransfer.ChannelID, link ipld.Link, size
 	))
 	defer span.End()
 
-	isNew, err := m.channels.DataQueued(chid, link.(cidlink.Link).Cid, size)
+	isNew, err := m.channels.DataQueued(chid, link.(cidlink.Link).Cid, size, index, unique)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ func (m *manager) OnDataQueued(chid datatransfer.ChannelID, link ipld.Link, size
 	return nil, nil
 }
 
-func (m *manager) OnDataSent(chid datatransfer.ChannelID, link ipld.Link, size uint64) error {
+func (m *manager) OnDataSent(chid datatransfer.ChannelID, link ipld.Link, size uint64, index int64, unique bool) error {
 
 	ctx, _ := m.spansIndex.SpanForChannel(context.TODO(), chid)
 	ctx, span := otel.Tracer("data-transfer").Start(ctx, "dataSent", trace.WithAttributes(
@@ -157,7 +157,7 @@ func (m *manager) OnDataSent(chid datatransfer.ChannelID, link ipld.Link, size u
 	))
 	defer span.End()
 
-	_, err := m.channels.DataSent(chid, link.(cidlink.Link).Cid, size)
+	err := m.channels.DataSent(chid, link.(cidlink.Link).Cid, size, index, unique)
 	return err
 }
 

--- a/impl/events.go
+++ b/impl/events.go
@@ -41,7 +41,7 @@ func (m *manager) OnChannelOpened(chid datatransfer.ChannelID) error {
 // It fires an event on the channel, updating the sum of received data and
 // calls revalidators so they can pause / resume the channel or send a
 // message over the transport.
-func (m *manager) OnDataReceived(chid datatransfer.ChannelID, link ipld.Link, size uint64, index int64) error {
+func (m *manager) OnDataReceived(chid datatransfer.ChannelID, link ipld.Link, size uint64, index int64, unique bool) error {
 	ctx, _ := m.spansIndex.SpanForChannel(context.TODO(), chid)
 	ctx, span := otel.Tracer("data-transfer").Start(ctx, "dataReceived", trace.WithAttributes(
 		attribute.String("channelID", chid.String()),
@@ -51,7 +51,7 @@ func (m *manager) OnDataReceived(chid datatransfer.ChannelID, link ipld.Link, si
 	))
 	defer span.End()
 
-	isNew, err := m.channels.DataReceived(chid, link.(cidlink.Link).Cid, size, index)
+	isNew, err := m.channels.DataReceived(chid, link.(cidlink.Link).Cid, size, index, unique)
 	if err != nil {
 		return err
 	}
@@ -157,7 +157,7 @@ func (m *manager) OnDataSent(chid datatransfer.ChannelID, link ipld.Link, size u
 	))
 	defer span.End()
 
-	err := m.channels.DataSent(chid, link.(cidlink.Link).Cid, size, index, unique)
+	_, err := m.channels.DataSent(chid, link.(cidlink.Link).Cid, size, index, unique)
 	return err
 }
 

--- a/impl/initiating_test.go
+++ b/impl/initiating_test.go
@@ -377,8 +377,8 @@ func TestDataTransferRestartInitiating(t *testing.T) {
 				testCids := testutil.GenerateCids(2)
 				ev, ok := h.dt.(datatransfer.EventsHandler)
 				require.True(t, ok)
-				require.NoError(t, ev.OnDataReceived(channelID, cidlink.Link{Cid: testCids[0]}, 12345, 1))
-				require.NoError(t, ev.OnDataReceived(channelID, cidlink.Link{Cid: testCids[1]}, 12345, 2))
+				require.NoError(t, ev.OnDataReceived(channelID, cidlink.Link{Cid: testCids[0]}, 12345, 1, true))
+				require.NoError(t, ev.OnDataReceived(channelID, cidlink.Link{Cid: testCids[1]}, 12345, 2, true))
 
 				// restart that pull channel
 				err = h.dt.RestartDataTransferChannel(ctx, channelID)

--- a/impl/responding_test.go
+++ b/impl/responding_test.go
@@ -287,7 +287,7 @@ func TestDataTransferResponding(t *testing.T) {
 			},
 			verify: func(t *testing.T, h *receiverHarness) {
 				h.network.Delegate.ReceiveRequest(h.ctx, h.peers[1], h.pushRequest)
-				err := h.transport.EventHandler.OnDataReceived(channelID(h.id, h.peers), cidlink.Link{Cid: testutil.GenerateCids(1)[0]}, 12345, 1)
+				err := h.transport.EventHandler.OnDataReceived(channelID(h.id, h.peers), cidlink.Link{Cid: testutil.GenerateCids(1)[0]}, 12345, 1, true)
 				require.EqualError(t, err, datatransfer.ErrPause.Error())
 				require.Len(t, h.network.SentMessages, 1)
 				response, ok := h.network.SentMessages[0].Message.(datatransfer.Response)
@@ -329,7 +329,7 @@ func TestDataTransferResponding(t *testing.T) {
 			},
 			verify: func(t *testing.T, h *receiverHarness) {
 				h.network.Delegate.ReceiveRequest(h.ctx, h.peers[1], h.pushRequest)
-				err := h.transport.EventHandler.OnDataReceived(channelID(h.id, h.peers), cidlink.Link{Cid: testutil.GenerateCids(1)[0]}, 12345, 1)
+				err := h.transport.EventHandler.OnDataReceived(channelID(h.id, h.peers), cidlink.Link{Cid: testutil.GenerateCids(1)[0]}, 12345, 1, true)
 				require.Error(t, err)
 				require.Len(t, h.network.SentMessages, 1)
 				response, ok := h.network.SentMessages[0].Message.(datatransfer.Response)
@@ -367,7 +367,7 @@ func TestDataTransferResponding(t *testing.T) {
 			},
 			verify: func(t *testing.T, h *receiverHarness) {
 				h.network.Delegate.ReceiveRequest(h.ctx, h.peers[1], h.pushRequest)
-				err := h.transport.EventHandler.OnDataReceived(channelID(h.id, h.peers), cidlink.Link{Cid: testutil.GenerateCids(1)[0]}, 12345, 1)
+				err := h.transport.EventHandler.OnDataReceived(channelID(h.id, h.peers), cidlink.Link{Cid: testutil.GenerateCids(1)[0]}, 12345, 1, true)
 				require.EqualError(t, err, datatransfer.ErrPause.Error())
 				require.Len(t, h.network.SentMessages, 1)
 				response, ok := h.network.SentMessages[0].Message.(datatransfer.Response)
@@ -645,8 +645,8 @@ func TestDataTransferRestartResponding(t *testing.T) {
 				testCids := testutil.GenerateCids(2)
 				ev, ok := h.dt.(datatransfer.EventsHandler)
 				require.True(t, ok)
-				require.NoError(t, ev.OnDataReceived(chid, cidlink.Link{Cid: testCids[0]}, 12345, 1))
-				require.NoError(t, ev.OnDataReceived(chid, cidlink.Link{Cid: testCids[1]}, 12345, 2))
+				require.NoError(t, ev.OnDataReceived(chid, cidlink.Link{Cid: testCids[0]}, 12345, 1, true))
+				require.NoError(t, ev.OnDataReceived(chid, cidlink.Link{Cid: testCids[1]}, 12345, 2, true))
 
 				// receive restart push request
 				req, err := message.NewRequest(h.pushRequest.TransferID(), true, false, h.voucher.Type(), h.voucher,
@@ -857,8 +857,8 @@ func TestDataTransferRestartResponding(t *testing.T) {
 				testCids := testutil.GenerateCids(2)
 				ev, ok := h.dt.(datatransfer.EventsHandler)
 				require.True(t, ok)
-				require.NoError(t, ev.OnDataReceived(channelID, cidlink.Link{Cid: testCids[0]}, 12345, 1))
-				require.NoError(t, ev.OnDataReceived(channelID, cidlink.Link{Cid: testCids[1]}, 12345, 2))
+				require.NoError(t, ev.OnDataReceived(channelID, cidlink.Link{Cid: testCids[0]}, 12345, 1, true))
+				require.NoError(t, ev.OnDataReceived(channelID, cidlink.Link{Cid: testCids[1]}, 12345, 2, true))
 
 				// send a request to restart the same pull channel
 				restartReq := message.RestartExistingChannelRequest(channelID)

--- a/impl/responding_test.go
+++ b/impl/responding_test.go
@@ -419,7 +419,7 @@ func TestDataTransferResponding(t *testing.T) {
 				msg, err := h.transport.EventHandler.OnDataQueued(
 					channelID(h.id, h.peers),
 					cidlink.Link{Cid: testutil.GenerateCids(1)[0]},
-					12345)
+					12345, 1, true)
 				require.EqualError(t, err, datatransfer.ErrPause.Error())
 				response, ok := msg.(datatransfer.Response)
 				require.True(t, ok)

--- a/impl/restart_integration_test.go
+++ b/impl/restart_integration_test.go
@@ -143,7 +143,6 @@ func TestRestartPush(t *testing.T) {
 			queued := make(chan uint64, totalIncrements*2)
 			sent := make(chan uint64, totalIncrements*2)
 			received := make(chan uint64, totalIncrements*2)
-			var receivedCids []cid.Cid
 			receivedTillNow := atomic.NewInt32(0)
 
 			// counters we will check at the end for correctness
@@ -182,15 +181,6 @@ func TestRestartPush(t *testing.T) {
 					finishedPeersLk.Lock()
 					{
 						finishedPeers = append(finishedPeers, channelState.SelfPeer())
-
-						// When the receiving peer completes, record received CIDs
-						// before they get cleaned up
-						if channelState.SelfPeer() == rh.peer2 {
-							chs, err := rh.dt2.InProgressChannels(rh.testCtx)
-							require.NoError(t, err)
-							require.Len(t, chs, 1)
-							receivedCids = chs[chid].ReceivedCids()
-						}
 					}
 					finishedPeersLk.Unlock()
 					finished <- channelState.SelfPeer()
@@ -263,7 +253,6 @@ func TestRestartPush(t *testing.T) {
 			require.NoError(t, err)
 
 			// verify all cids are present on the receiver
-			require.Equal(t, totalIncrements, len(receivedCids))
 
 			testutil.VerifyHasFile(rh.testCtx, t, rh.destDagService, rh.root, rh.origBytes)
 			rh.sv.VerifyExpectations(t)

--- a/transport.go
+++ b/transport.go
@@ -23,7 +23,7 @@ type EventsHandler interface {
 	// - nil = proceed with sending data
 	// - error = cancel this request
 	// - err == ErrPause - pause this request
-	OnDataReceived(chid ChannelID, link ipld.Link, size uint64, index int64) error
+	OnDataReceived(chid ChannelID, link ipld.Link, size uint64, index int64, unique bool) error
 
 	// OnDataQueued is called when data is queued for sending for the given channel ID
 	// return values are:

--- a/transport.go
+++ b/transport.go
@@ -32,10 +32,10 @@ type EventsHandler interface {
 	// - nil = proceed with sending data
 	// - error = cancel this request
 	// - err == ErrPause - pause this request
-	OnDataQueued(chid ChannelID, link ipld.Link, size uint64) (Message, error)
+	OnDataQueued(chid ChannelID, link ipld.Link, size uint64, index int64, unique bool) (Message, error)
 
 	// OnDataSent is called when we send data for the given channel ID
-	OnDataSent(chid ChannelID, link ipld.Link, size uint64) error
+	OnDataSent(chid ChannelID, link ipld.Link, size uint64, index int64, unique bool) error
 
 	// OnTransferQueued is called when a new data transfer request is queued in the transport layer.
 	OnTransferQueued(chid ChannelID)

--- a/transport/graphsync/graphsync.go
+++ b/transport/graphsync/graphsync.go
@@ -527,7 +527,7 @@ func (t *Transport) gsIncomingBlockHook(p peer.ID, response graphsync.ResponseDa
 		return
 	}
 
-	err := t.events.OnDataReceived(chid, block.Link(), block.BlockSize(), block.Index())
+	err := t.events.OnDataReceived(chid, block.Link(), block.BlockSize(), block.Index(), block.BlockSizeOnWire() != 0)
 	if err != nil && err != datatransfer.ErrPause {
 		hookActions.TerminateWithError(err)
 		return

--- a/transport/graphsync/graphsync.go
+++ b/transport/graphsync/graphsync.go
@@ -553,7 +553,7 @@ func (t *Transport) gsBlockSentHook(p peer.ID, request graphsync.RequestData, bl
 		return
 	}
 
-	if err := t.events.OnDataSent(chid, block.Link(), block.BlockSize()); err != nil {
+	if err := t.events.OnDataSent(chid, block.Link(), block.BlockSize(), block.Index(), block.BlockSizeOnWire() != 0); err != nil {
 		log.Errorf("failed to process data sent: %+v", err)
 	}
 }
@@ -577,7 +577,7 @@ func (t *Transport) gsOutgoingBlockHook(p peer.ID, request graphsync.RequestData
 	// peer. It can return ErrPause to pause the response (eg if payment is
 	// required) and it can return a message that will be sent with the block
 	// (eg to ask for payment).
-	msg, err := t.events.OnDataQueued(chid, block.Link(), block.BlockSize())
+	msg, err := t.events.OnDataQueued(chid, block.Link(), block.BlockSize(), block.Index(), block.BlockSizeOnWire() != 0)
 	if err != nil && err != datatransfer.ErrPause {
 		hookActions.TerminateWithError(err)
 		return

--- a/transport/graphsync/graphsync_test.go
+++ b/transport/graphsync/graphsync_test.go
@@ -1238,7 +1238,7 @@ func (fe *fakeEvents) OnChannelOpened(chid datatransfer.ChannelID) error {
 	return fe.OnChannelOpenedError
 }
 
-func (fe *fakeEvents) OnDataReceived(chid datatransfer.ChannelID, link ipld.Link, size uint64, index int64) error {
+func (fe *fakeEvents) OnDataReceived(chid datatransfer.ChannelID, link ipld.Link, size uint64, index int64, unique bool) error {
 	fe.OnDataReceivedCalled = true
 	return fe.OnDataReceivedError
 }

--- a/transport/graphsync/graphsync_test.go
+++ b/transport/graphsync/graphsync_test.go
@@ -1199,7 +1199,7 @@ type fakeEvents struct {
 	ResponseReceivedResponse datatransfer.Response
 }
 
-func (fe *fakeEvents) OnDataQueued(chid datatransfer.ChannelID, link ipld.Link, size uint64) (datatransfer.Message, error) {
+func (fe *fakeEvents) OnDataQueued(chid datatransfer.ChannelID, link ipld.Link, size uint64, index int64, unique bool) (datatransfer.Message, error) {
 	fe.OnDataQueuedCalled = true
 
 	return fe.OnDataQueuedMessage, fe.OnDataQueuedError
@@ -1243,7 +1243,7 @@ func (fe *fakeEvents) OnDataReceived(chid datatransfer.ChannelID, link ipld.Link
 	return fe.OnDataReceivedError
 }
 
-func (fe *fakeEvents) OnDataSent(chid datatransfer.ChannelID, link ipld.Link, size uint64) error {
+func (fe *fakeEvents) OnDataSent(chid datatransfer.ChannelID, link ipld.Link, size uint64, index int64, unique bool) error {
 	fe.OnDataSentCalled = true
 	return nil
 }
@@ -1456,6 +1456,14 @@ func (m *mockChannelState) ReceivedCidsLen() int {
 
 func (m *mockChannelState) ReceivedCidsTotal() int64 {
 	return (int64)(len(m.receivedCids))
+}
+
+func (m *mockChannelState) QueuedCidsTotal() int64 {
+	panic("implement me")
+}
+
+func (m *mockChannelState) SentCidsTotal() int64 {
+	panic("implement me")
 }
 
 func (m *mockChannelState) Queued() uint64 {

--- a/types.go
+++ b/types.go
@@ -139,6 +139,14 @@ type ChannelState interface {
 	// on the channel - note that a block can exist in more than one place in the DAG
 	ReceivedCidsTotal() int64
 
+	// QueuedCidsTotal returns the number of (non-unique) cids queued so far
+	// on the channel - note that a block can exist in more than one place in the DAG
+	QueuedCidsTotal() int64
+
+	// SentCidsTotal returns the number of (non-unique) cids sent so far
+	// on the channel - note that a block can exist in more than one place in the DAG
+	SentCidsTotal() int64
+
 	// Queued returns the number of bytes read from the node and queued for sending
 	Queued() uint64
 


### PR DESCRIPTION
# Goals

Remove CID List tracking from data transfer, improve performance, simplify protocol

I'm splitting this into two PRs to make review easier:
- This PR removes CID lists for the data sender. It removes reliance on CID lists to determine the accurate position in a data stream across restarts and whether we've seen blocks before
- A second PR will contain all the breaking changes to remove unused code, remove deprecated protocols, etc

# Implementation

- add a SentCidsTotal and a QueuedCidsTotal to every channel state similar to ReceivedCidsTotal
- pass GraphSync's information about whether blocks are seen for the first time through the transport event hooks
- add a blockIndexCache that maintains an in memory cache of the current indexes -- this allows us not to determine ahead if a block is past the most recent block received/sent/queued
- combining most recent block received check (are we dealing with data at the tip of the traversal?) with graphsyncs uniqueness check (is this data a block that occurred earlier) to effectively replicate the functionality of the cidsets, but in more performant ways
- this paves the way to remove cidsets entirely as well as older protocols - this PR already no longer stores them for the listener