### PR TITLE
Add opened event name

### DIFF
--- a/events.go
+++ b/events.go
@@ -144,6 +144,7 @@ var Events = map[EventCode]string{
 	ReceiveDataError:            "ReceiveDataError",
 	TransferRequestQueued:       "TransferRequestQueued",
 	RequestCancelled:            "RequestCancelled",
+	Opened:                      "Opened",
 }
 
 // Event is a struct containing information about a data transfer event


### PR DESCRIPTION
The name for the `Opened` event was missing.