### PR TITLE
feat(graphsync): remove peer id tracking

### DIFF
--- a/transport/graphsync/gskeychidmap_test.go
+++ b/transport/graphsync/gskeychidmap_test.go
@@ -9,60 +9,54 @@ import (
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 )
 
-func TestGSKeyToChannelIDMap(t *testing.T) {
-	m := newGSKeyToChannelIDMap()
-	gsk1 := graphsyncKey{
-		requestID: graphsync.NewRequestID(),
-		p:         "p",
-	}
-	gsk2 := graphsyncKey{
-		requestID: graphsync.NewRequestID(),
-		p:         "p",
-	}
+func TestRequestIDToChannelIDMap(t *testing.T) {
+	m := newRequestIDToChannelIDMap()
+	requestID1 := graphsync.NewRequestID()
+	requestID2 := graphsync.NewRequestID()
 	chid := datatransfer.ChannelID{
 		Initiator: "i",
 		Responder: "r",
 		ID:        1,
 	}
 
-	_, ok := m.load(gsk1)
+	_, ok := m.load(requestID1)
 	require.False(t, ok)
 
-	_, any := m.any(gsk1)
+	_, any := m.any(requestID1)
 	require.False(t, any)
 
-	m.set(gsk1, chid)
-	ret, ok := m.load(gsk1)
+	m.set(requestID1, false, chid)
+	ret, ok := m.load(requestID1)
 	require.True(t, ok)
 	require.Equal(t, chid, ret)
 
-	ret, any = m.any(gsk1)
+	ret, any = m.any(requestID1)
 	require.True(t, any)
 	require.Equal(t, chid, ret)
 
-	_, any = m.any(gsk2)
+	_, any = m.any(requestID2)
 	require.False(t, any)
 
-	m.set(gsk2, chid)
-	chid, any = m.any(gsk2)
+	m.set(requestID2, true, chid)
+	chid, any = m.any(requestID2)
 	require.True(t, any)
 	require.Equal(t, chid, ret)
 
-	var ks []graphsyncKey
+	var ks []graphsync.RequestID
 	var chids []datatransfer.ChannelID
-	m.forEach(func(k graphsyncKey, chid datatransfer.ChannelID) {
+	m.forEach(func(k graphsync.RequestID, isSending bool, chid datatransfer.ChannelID) {
 		ks = append(ks, k)
 		chids = append(chids, chid)
 	})
 	require.Len(t, ks, 2)
-	require.Contains(t, ks, gsk1)
-	require.Contains(t, ks, gsk2)
+	require.Contains(t, ks, requestID1)
+	require.Contains(t, ks, requestID2)
 	require.Len(t, chids, 2)
 	require.Contains(t, chids, chid)
 
 	m.deleteRefs(chid)
-	_, ok = m.load(gsk1)
+	_, ok = m.load(requestID1)
 	require.False(t, ok)
-	_, ok = m.load(gsk2)
+	_, ok = m.load(requestID2)
 	require.False(t, ok)
 }


### PR DESCRIPTION
# Goals

Simplify graphsync transport slightly -- we no longer need to track peer.ID for graphsync maps

# Implementation

- remove graphsyncKey type
- key requests on RequestID only
- record sending vs receiving for diagnostics