### PR TITLE
nullable TransferRequest1_1.RestartChannel

### DIFF
--- a/message/message1_1/message.go
+++ b/message/message1_1/message.go
@@ -52,7 +52,7 @@ func NewRequest(id datatransfer.TransferID, isRestart bool, isPull bool, vtype d
 func RestartExistingChannelRequest(channelId datatransfer.ChannelID) datatransfer.Request {
 
 	return &TransferRequest1_1{Type: uint64(types.RestartExistingChannelRequestMessage),
-		RestartChannel: channelId}
+		RestartChannel: &channelId}
 }
 
 // CancelRequest request generates a request to cancel an in progress request

--- a/message/message1_1/transfer_request.go
+++ b/message/message1_1/transfer_request.go
@@ -33,7 +33,7 @@ type TransferRequest1_1 struct {
 	VTyp   datatransfer.TypeIdentifier
 	XferID uint64
 
-	RestartChannel datatransfer.ChannelID
+	RestartChannel *datatransfer.ChannelID
 }
 
 func (trq *TransferRequest1_1) MessageForProtocol(targetProtocol protocol.ID) (datatransfer.Message, error) {
@@ -62,7 +62,10 @@ func (trq *TransferRequest1_1) RestartChannelId() (datatransfer.ChannelID, error
 	if !trq.IsRestartExistingChannelRequest() {
 		return datatransfer.ChannelID{}, xerrors.New("not a restart request")
 	}
-	return trq.RestartChannel, nil
+	if trq.RestartChannel == nil {
+		return datatransfer.ChannelID{}, xerrors.New("TransferRequest1_1.RestartChannel = nil")
+	}
+	return *trq.RestartChannel, nil
 }
 
 func (trq *TransferRequest1_1) IsNew() bool {

--- a/message/message1_1/transfer_request_cbor_gen.go
+++ b/message/message1_1/transfer_request_cbor_gen.go
@@ -381,8 +381,18 @@ func (t *TransferRequest1_1) UnmarshalCBOR(r io.Reader) error {
 
 			{
 
-				if err := t.RestartChannel.UnmarshalCBOR(br); err != nil {
-					return xerrors.Errorf("unmarshaling t.RestartChannel: %w", err)
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					t.RestartChannel = new(datatransfer.ChannelID)
+					if err := t.RestartChannel.UnmarshalCBOR(br); err != nil {
+						return xerrors.Errorf("unmarshaling t.RestartChannel pointer: %w", err)
+					}
 				}
 
 			}

--- a/message/message1_1prime/message.go
+++ b/message/message1_1prime/message.go
@@ -54,7 +54,7 @@ func NewRequest(id datatransfer.TransferID, isRestart bool, isPull bool, vtype d
 func RestartExistingChannelRequest(channelId datatransfer.ChannelID) datatransfer.Request {
 	return &TransferRequest1_1{
 		MessageType:    uint64(types.RestartExistingChannelRequestMessage),
-		RestartChannel: channelId,
+		RestartChannel: &channelId,
 	}
 }
 

--- a/message/message1_1prime/schema.ipldsch
+++ b/message/message1_1prime/schema.ipldsch
@@ -18,7 +18,7 @@ type TransferRequest struct {
 	VoucherPtr            nullable Any            (rename "Vouch")
 	VoucherTypeIdentifier          TypeIdentifier (rename "VTyp")
 	TransferId                     Int            (rename "XferID")
-	RestartChannel                 ChannelID
+	RestartChannel        nullable ChannelID
 }
 
 type TransferResponse struct {

--- a/message/message1_1prime/transfer_request.go
+++ b/message/message1_1prime/transfer_request.go
@@ -27,7 +27,7 @@ type TransferRequest1_1 struct {
 	VoucherPtr            *datamodel.Node
 	VoucherTypeIdentifier datatransfer.TypeIdentifier
 	TransferId            uint64
-	RestartChannel        datatransfer.ChannelID
+	RestartChannel        *datatransfer.ChannelID
 }
 
 func (trq *TransferRequest1_1) MessageForProtocol(targetProtocol protocol.ID) (datatransfer.Message, error) {
@@ -56,7 +56,10 @@ func (trq *TransferRequest1_1) RestartChannelId() (datatransfer.ChannelID, error
 	if !trq.IsRestartExistingChannelRequest() {
 		return datatransfer.ChannelID{}, xerrors.New("not a restart request")
 	}
-	return trq.RestartChannel, nil
+	if trq.RestartChannel == nil {
+		return datatransfer.ChannelID{}, xerrors.New("TransferRequest1_1.RestartChannel = nil")
+	}
+	return *trq.RestartChannel, nil
 }
 
 func (trq *TransferRequest1_1) IsNew() bool {


### PR DESCRIPTION
Fixes ambiguos `TransferRequest1_1.RestartChannel` cbor encoding - make it nullable.