### PR TITLE
fix new network error introduced decoding w/ go-ipld-prime

### DIFF
--- a/network/libp2p_impl.go
+++ b/network/libp2p_impl.go
@@ -249,7 +249,7 @@ func (dtnet *libp2pDataTransferNetwork) handleNewStream(s network.Stream) {
 		}
 
 		if err != nil {
-			if err != io.EOF {
+			if err != io.EOF && err != io.ErrUnexpectedEOF {
 				s.Reset() // nolint: errcheck,gosec
 				go dtnet.receiver.ReceiveError(err)
 				log.Debugf("net handleNewStream from %s error: %s", p, err)


### PR DESCRIPTION
We're getting an "Unexpected EOF" error on streams when they close cause we used dagcbor.Decode to decode messages, and it converts regular EOF to UnexpectedEOF if it encounters EOF trying to decode the message. I'm not sure this is incorrect behavior -- actually I think it's probably the right thing. What we really should be doing is using msgio and writing a varint around each message, and dealing with the EOF there before calling dagcbor.Decode. But that's a protocol change. So for the moment, this PR simply adds UnexpectedEOF to the checks for an end of stream.