### PR TITLE
Handle transfers that never send a remote request

### DIFF
--- a/channels/channels_test.go
+++ b/channels/channels_test.go
@@ -132,6 +132,8 @@ func TestChannels(t *testing.T) {
 		chid, err := channelList.CreateNew(peers[0], tid1, cids[0], selector, fv1, peers[0], peers[0], peers[1])
 		require.NoError(t, err)
 		checkEvent(ctx, t, received, datatransfer.Open)
+		require.NoError(t, channelList.Accept(chid))
+		checkEvent(ctx, t, received, datatransfer.Accept)
 
 		// move the channel to `TransferFinished` state.
 		require.NoError(t, channelList.FinishTransfer(chid))


### PR DESCRIPTION
# Goals

This is an alternative to https://github.com/ipfs/go-graphsync/pull/370 that actually modifies go-data-transfer so that it succeeds in cases where graphsync never fires off a request. I'm not totally sure if this is the "right implementation" -- it is the only one that can get all go-legs tests to pass. It turns out https://github.com/ipfs/go-graphsync/pull/370 has it's own problems cause the legs rate limiter relies on some very specific assumptions about how go-graphsync should work.

# Implementation

This is actually a really simple change it turns out -- if we finish a transfer without ever actually getting a response accepting our request from a remote peer, just consider it complete.

It's a bit hacky, and we should consider a more permaneant solution, but it does make some level of intuitive sense -- a data transfer can skip the finalization process if no remote transfer was ever actually executed.