### PR TITLE
Refactor revalidators v2

### DIFF
--- a/impl/impl.go
+++ b/impl/impl.go
@@ -368,7 +368,7 @@ func (m *manager) updateValidationStatus(ctx context.Context, chid datatransfer.
 func (m *manager) processValidationUpdate(ctx context.Context, chid datatransfer.ChannelID, result datatransfer.ValidationResult) (datatransfer.ChannelState, datatransfer.Response, error) {
 
 	// read the channel state
-	chst, err := m.channels.GetByID(context.TODO(), chid)
+	chst, err := m.channels.GetByID(ctx, chid)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/impl/impl.go
+++ b/impl/impl.go
@@ -24,6 +24,7 @@ import (
 	"github.com/filecoin-project/go-data-transfer/v2/channels"
 	"github.com/filecoin-project/go-data-transfer/v2/encoding"
 	"github.com/filecoin-project/go-data-transfer/v2/message"
+	"github.com/filecoin-project/go-data-transfer/v2/message/types"
 	"github.com/filecoin-project/go-data-transfer/v2/network"
 	"github.com/filecoin-project/go-data-transfer/v2/registry"
 	"github.com/filecoin-project/go-data-transfer/v2/tracing"
@@ -334,8 +335,106 @@ func (m *manager) SendVoucherResult(ctx context.Context, channelID datatransfer.
 	return m.channels.NewVoucherResult(channelID, voucherResult)
 }
 
-func (m *manager) SetDataLimit(ctx context.Context, chid datatransfer.ChannelID, totalData uint64, stopAtEnd bool) {
+func (m *manager) UpdateValidationStatus(ctx context.Context, chid datatransfer.ChannelID, result datatransfer.ValidationResult) error {
+	ctx, _ = m.spansIndex.SpanForChannel(ctx, chid)
+	ctx, span := otel.Tracer("data-transfer").Start(ctx, "updateValidationStatus", trace.WithAttributes(
+		attribute.String("channelID", chid.String()),
+	))
+	err := m.updateValidationStatus(ctx, chid, result)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	span.End()
+	return err
+}
 
+// updateValidationStatus is the implementation of the public method, which wraps this private method
+// in a trace
+func (m *manager) updateValidationStatus(ctx context.Context, chid datatransfer.ChannelID, result datatransfer.ValidationResult) error {
+	// first check if we are the responder -- only the responder can call UpdateValidationStatus
+	if chid.Initiator == m.peerID {
+		err := errors.New("cannot send voucher result for request we initiated")
+		return err
+	}
+
+	// dispatch channel events and generate a response message
+	chst, response, err := m.processValidationUpdate(ctx, chid, result)
+
+	// dispatch transport updates
+	return m.handleTransportUpdate(ctx, chst, response, result, err)
+}
+
+func (m *manager) processValidationUpdate(ctx context.Context, chid datatransfer.ChannelID, result datatransfer.ValidationResult) (datatransfer.ChannelState, datatransfer.Response, error) {
+
+	// read the channel state
+	chst, err := m.channels.GetByID(context.TODO(), chid)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// if the request is now rejected, error the channel
+	if !result.Accepted {
+		err = m.recordRejectedValidationEvents(chid, result)
+	} else {
+		err = m.recordAcceptedValidationEvents(chst, result)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// generate a response message
+	messageType := types.VoucherResultMessage
+	if chst.Status() == datatransfer.Finalizing {
+		messageType = types.CompleteMessage
+	}
+	response, msgErr := message.ValidationResultResponse(messageType, chst.TransferID(), result, err)
+	if msgErr != nil {
+		return nil, nil, msgErr
+	}
+
+	// return the response message and any errors
+	return chst, response, nil
+}
+
+// handleTransportUpdate updates the transport based on the validation status and the
+// response message
+// TODO: the ordering here is a bit sensitive, and the transport should
+// be refactored to accept multiple operations at once and order these itself
+func (m *manager) handleTransportUpdate(
+	ctx context.Context,
+	chst datatransfer.ChannelState,
+	response datatransfer.Message,
+	result datatransfer.ValidationResult,
+	resultErr error,
+) error {
+
+	// resume channel as needed, sending the response message immediately and returning
+	if resultErr == nil && result.Accepted && !result.LeaveRequestPaused {
+		if chst.Status().IsResponderPaused() && !chst.Status().InFinalization() {
+			return m.transport.(datatransfer.PauseableTransport).ResumeChannel(ctx, response, chst.ChannelID())
+		}
+	}
+
+	// send a response message
+	if response != nil {
+		if err := m.dataTransferNetwork.SendMessage(ctx, chst.ChannelID().Initiator, response); err != nil {
+			return err
+		}
+	}
+
+	// close the channel as needed
+	if resultErr != nil || !result.Accepted {
+		m.transport.CloseChannel(ctx, chst.ChannelID())
+		return resultErr
+	}
+
+	// pause the channel as needed
+	if result.LeaveRequestPaused && !chst.Status().IsResponderPaused() && !chst.Status().InFinalization() {
+		return m.transport.(datatransfer.PauseableTransport).PauseChannel(ctx, chst.ChannelID())
+	}
+
+	return nil
 }
 
 // close an open channel (effectively a cancel)

--- a/impl/initiating_test.go
+++ b/impl/initiating_test.go
@@ -462,7 +462,7 @@ func TestDataTransferRestartInitiating(t *testing.T) {
 				require.Len(t, h.voucherValidator.ValidationsReceived, 1)
 
 				// restart the push request received above and validate it
-				h.voucherValidator.StubRevalidationResult(datatransfer.ValidationResult{Accepted: true})
+				h.voucherValidator.StubRestartResult(datatransfer.ValidationResult{Accepted: true})
 				chid := datatransfer.ChannelID{Initiator: h.peers[1], Responder: h.peers[0], ID: h.pushRequest.TransferID()}
 				require.NoError(t, h.dt.RestartDataTransferChannel(ctx, chid))
 				require.Len(t, h.voucherValidator.RevalidationsReceived, 1)
@@ -503,8 +503,8 @@ func TestDataTransferRestartInitiating(t *testing.T) {
 				require.Len(t, h.voucherValidator.ValidationsReceived, 1)
 
 				// restart the pull request received above
-				h.voucherValidator.ExpectSuccessRevalidation()
-				h.voucherValidator.StubRevalidationResult(datatransfer.ValidationResult{Accepted: true})
+				h.voucherValidator.ExpectSuccessValidateRestart()
+				h.voucherValidator.StubRestartResult(datatransfer.ValidationResult{Accepted: true})
 				chid := datatransfer.ChannelID{Initiator: h.peers[1], Responder: h.peers[0], ID: h.pullRequest.TransferID()}
 				require.NoError(t, h.dt.RestartDataTransferChannel(ctx, chid))
 				require.Len(t, h.transport.OpenedChannels, 0)
@@ -544,8 +544,8 @@ func TestDataTransferRestartInitiating(t *testing.T) {
 				require.Len(t, h.voucherValidator.ValidationsReceived, 1)
 
 				// restart the pull request received above
-				h.voucherValidator.ExpectSuccessRevalidation()
-				h.voucherValidator.StubRevalidationResult(datatransfer.ValidationResult{Accepted: false})
+				h.voucherValidator.ExpectSuccessValidateRestart()
+				h.voucherValidator.StubRestartResult(datatransfer.ValidationResult{Accepted: false})
 				chid := datatransfer.ChannelID{Initiator: h.peers[1], Responder: h.peers[0], ID: h.pullRequest.TransferID()}
 				require.EqualError(t, h.dt.RestartDataTransferChannel(ctx, chid), datatransfer.ErrRejected.Error())
 			},
@@ -566,8 +566,8 @@ func TestDataTransferRestartInitiating(t *testing.T) {
 				require.Len(t, h.voucherValidator.ValidationsReceived, 1)
 
 				// restart the pull request received above
-				h.voucherValidator.ExpectSuccessRevalidation()
-				h.voucherValidator.StubRevalidationResult(datatransfer.ValidationResult{Accepted: false})
+				h.voucherValidator.ExpectSuccessValidateRestart()
+				h.voucherValidator.StubRestartResult(datatransfer.ValidationResult{Accepted: false})
 				chid := datatransfer.ChannelID{Initiator: h.peers[1], Responder: h.peers[0], ID: h.pushRequest.TransferID()}
 				require.EqualError(t, h.dt.RestartDataTransferChannel(ctx, chid), datatransfer.ErrRejected.Error())
 			},

--- a/impl/receiving_requests.go
+++ b/impl/receiving_requests.go
@@ -250,23 +250,6 @@ func (m *manager) recordRejectedValidationEvents(chid datatransfer.ChannelID, re
 func (m *manager) recordAcceptedValidationEvents(chst datatransfer.ChannelState, result datatransfer.ValidationResult) error {
 	chid := chst.ChannelID()
 
-	// pause or resume the request as neccesary
-	if result.LeaveRequestPaused(chst) {
-		if !chst.Status().IsResponderPaused() {
-			err := m.channels.PauseResponder(chid)
-			if err != nil {
-				return err
-			}
-		}
-	} else {
-		if chst.Status().IsResponderPaused() {
-			err := m.channels.ResumeResponder(chid)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
 	// record the voucher result if present
 	if result.VoucherResult != nil {
 		err := m.channels.NewVoucherResult(chid, result.VoucherResult)
@@ -290,6 +273,24 @@ func (m *manager) recordAcceptedValidationEvents(chst datatransfer.ChannelState,
 			return err
 		}
 	}
+
+	// pause or resume the request as neccesary
+	if result.LeaveRequestPaused(chst) {
+		if !chst.Status().IsResponderPaused() {
+			err := m.channels.PauseResponder(chid)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		if chst.Status().IsResponderPaused() {
+			err := m.channels.ResumeResponder(chid)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/impl/receiving_requests.go
+++ b/impl/receiving_requests.go
@@ -2,7 +2,6 @@ package impl
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
@@ -24,13 +23,13 @@ func (m *manager) receiveNewRequest(chid datatransfer.ChannelID, incoming datatr
 	result, err := m.acceptRequest(chid, incoming)
 
 	// generate a response message
-	msg, msgErr := message.ValidationResultResponse(types.NewMessage, incoming.TransferID(), result, err)
+	msg, msgErr := message.ValidationResultResponse(types.NewMessage, incoming.TransferID(), result, err, result.ForcePause)
 	if msgErr != nil {
 		return nil, msgErr
 	}
 
 	// return the response message and any errors
-	return msg, m.requestError(result, err, false)
+	return msg, m.requestError(result, err, result.ForcePause)
 }
 
 // acceptRequest performs processing (including validation) on a new incoming request
@@ -113,69 +112,70 @@ func (m *manager) receiveRestartRequest(chid datatransfer.ChannelID, incoming da
 	log.Infof("channel %s: received restart request", chid)
 
 	// process the restart message, including validations
-	result, err := m.restartRequest(chid, incoming)
+	stayPaused, result, err := m.restartRequest(chid, incoming)
 
 	// generate a response message
-	msg, msgErr := message.ValidationResultResponse(types.RestartMessage, incoming.TransferID(), result, err)
+	msg, msgErr := message.ValidationResultResponse(types.RestartMessage, incoming.TransferID(), result, err, stayPaused)
 	if msgErr != nil {
 		return nil, msgErr
 	}
 
 	// return the response message and any errors
-	return msg, m.requestError(result, err, false)
+	return msg, m.requestError(result, err, result.ForcePause)
 }
 
 // restartRequest performs processing (including validation) on a incoming restart request
 func (m *manager) restartRequest(chid datatransfer.ChannelID,
-	incoming datatransfer.Request) (datatransfer.ValidationResult, error) {
+	incoming datatransfer.Request) (bool, datatransfer.ValidationResult, error) {
 
 	// restart requests are invalid if we the initiator
 	// (the responder must send a "restart existing channel request")
 	initiator := chid.Initiator
 	if m.peerID == initiator {
-		return datatransfer.ValidationResult{}, xerrors.New("initiator cannot be manager peer for a restart request")
+		return false, datatransfer.ValidationResult{}, xerrors.New("initiator cannot be manager peer for a restart request")
 	}
 
 	// valide that the request parameters match the original request
 	// TODO: not sure this is needed -- the request parameters cannot change,
 	// so perhaps the solution is just to ignore them in the message
 	if err := m.validateRestartRequest(context.Background(), initiator, chid, incoming); err != nil {
-		return datatransfer.ValidationResult{}, xerrors.Errorf("restart request for channel %s failed validation: %w", chid, err)
+		return false, datatransfer.ValidationResult{}, xerrors.Errorf("restart request for channel %s failed validation: %w", chid, err)
 	}
 
 	// read the channel state
 	chst, err := m.channels.GetByID(context.TODO(), chid)
 	if err != nil {
-		return datatransfer.ValidationResult{}, err
+		return false, datatransfer.ValidationResult{}, err
 	}
 
 	// perform a revalidation against the last voucher
 	result, err := m.validateRestart(chst)
+	stayPaused := result.LeaveRequestPaused(chst)
 
 	// if an error occurred during validation return
 	if err != nil {
-		return result, err
+		return stayPaused, result, err
 	}
 
 	// if the request is now rejected, error the channel
 	if !result.Accepted {
-		return result, m.recordRejectedValidationEvents(chid, result)
+		return stayPaused, result, m.recordRejectedValidationEvents(chid, result)
 	}
 
 	// record the restart events
 	if err := m.channels.Restart(chid); err != nil {
-		return result, xerrors.Errorf("failed to restart channel %s: %w", chid, err)
+		return stayPaused, result, xerrors.Errorf("failed to restart channel %s: %w", chid, err)
 	}
 
 	// record validation events
 	if err := m.recordAcceptedValidationEvents(chst, result); err != nil {
-		return result, err
+		return stayPaused, result, err
 	}
 
 	// configure the transport
 	voucher, err := m.decodeVoucher(incoming)
 	if err != nil {
-		return result, err
+		return stayPaused, result, err
 	}
 	processor, has := m.transportConfigurers.Processor(voucher.Type())
 	if has {
@@ -183,14 +183,13 @@ func (m *manager) restartRequest(chid datatransfer.ChannelID,
 		transportConfigurer(chid, voucher, m.transport)
 	}
 	m.dataTransferNetwork.Protect(initiator, chid.String())
-	return result, nil
+	return stayPaused, result, nil
 }
 
 // processUpdateVoucher handles an incoming request message with an updated voucher
 func (m *manager) processUpdateVoucher(chid datatransfer.ChannelID, request datatransfer.Request) (datatransfer.Response, error) {
 	// decode the voucher and save it on the channel
 	vouch, err := m.decodeVoucher(request)
-	fmt.Println(err)
 	if err != nil {
 		return nil, err
 	}
@@ -223,18 +222,15 @@ func (m *manager) receiveUpdateRequest(chid datatransfer.ChannelID, request data
 // ErrPause / ErrResume based off the validation result
 // TODO: get away from using ErrPause/ErrResume to indicate pause resume,
 // which would remove the need for most of this method
-func (m *manager) requestError(result datatransfer.ValidationResult, resultErr error, handleResumes bool) error {
+func (m *manager) requestError(result datatransfer.ValidationResult, resultErr error, stayPaused bool) error {
 	if resultErr != nil {
 		return resultErr
 	}
 	if !result.Accepted {
 		return datatransfer.ErrRejected
 	}
-	if result.LeaveRequestPaused {
+	if stayPaused {
 		return datatransfer.ErrPause
-	}
-	if handleResumes {
-		return datatransfer.ErrResume
 	}
 	return nil
 }
@@ -255,7 +251,7 @@ func (m *manager) recordAcceptedValidationEvents(chst datatransfer.ChannelState,
 	chid := chst.ChannelID()
 
 	// pause or resume the request as neccesary
-	if result.LeaveRequestPaused {
+	if result.LeaveRequestPaused(chst) {
 		if !chst.Status().IsResponderPaused() {
 			err := m.channels.PauseResponder(chid)
 			if err != nil {

--- a/impl/responding_test.go
+++ b/impl/responding_test.go
@@ -115,7 +115,7 @@ func TestDataTransferResponding(t *testing.T) {
 		"new push request pauses": {
 			configureValidator: func(sv *testutil.StubbedValidator) {
 				sv.ExpectSuccessPush()
-				sv.StubResult(datatransfer.ValidationResult{Accepted: true, LeaveRequestPaused: true, VoucherResult: testutil.NewFakeDTType()})
+				sv.StubResult(datatransfer.ValidationResult{Accepted: true, ForcePause: true, VoucherResult: testutil.NewFakeDTType()})
 			},
 			verify: func(t *testing.T, h *receiverHarness) {
 				h.network.Delegate.ReceiveRequest(h.ctx, h.peers[1], h.pushRequest)
@@ -204,7 +204,7 @@ func TestDataTransferResponding(t *testing.T) {
 		"new pull request pauses": {
 			configureValidator: func(sv *testutil.StubbedValidator) {
 				sv.ExpectSuccessPull()
-				sv.StubResult(datatransfer.ValidationResult{Accepted: true, LeaveRequestPaused: true})
+				sv.StubResult(datatransfer.ValidationResult{Accepted: true, ForcePause: true})
 			},
 			verify: func(t *testing.T, h *receiverHarness) {
 				response, err := h.transport.EventHandler.OnRequestReceived(channelID(h.id, h.peers), h.pullRequest)

--- a/impl/responding_test.go
+++ b/impl/responding_test.go
@@ -356,9 +356,9 @@ func TestDataTransferResponding(t *testing.T) {
 				datatransfer.DataReceived,
 				datatransfer.DataLimitExceeded,
 				datatransfer.NewVoucher,
-				datatransfer.ResumeResponder,
 				datatransfer.NewVoucherResult,
 				datatransfer.SetDataLimit,
+				datatransfer.ResumeResponder,
 			},
 			configureValidator: func(sv *testutil.StubbedValidator) {
 				sv.ExpectSuccessPush()
@@ -455,9 +455,9 @@ func TestDataTransferResponding(t *testing.T) {
 				datatransfer.DataQueued,
 				datatransfer.DataLimitExceeded,
 				datatransfer.NewVoucher,
-				datatransfer.ResumeResponder,
 				datatransfer.NewVoucherResult,
 				datatransfer.SetDataLimit,
+				datatransfer.ResumeResponder,
 			},
 			configureValidator: func(sv *testutil.StubbedValidator) {
 				sv.ExpectSuccessPull()
@@ -505,9 +505,9 @@ func TestDataTransferResponding(t *testing.T) {
 				datatransfer.SetRequiresFinalization,
 				datatransfer.BeginFinalizing,
 				datatransfer.NewVoucher,
-				datatransfer.ResumeResponder,
 				datatransfer.NewVoucherResult,
 				datatransfer.SetRequiresFinalization,
+				datatransfer.ResumeResponder,
 				datatransfer.CleanupComplete,
 			},
 			configureValidator: func(sv *testutil.StubbedValidator) {

--- a/impl/restart.go
+++ b/impl/restart.go
@@ -32,7 +32,7 @@ const (
 )
 
 func (m *manager) restartManagerPeerReceivePush(ctx context.Context, channel datatransfer.ChannelState) error {
-	result, err := m.revalidate(channel)
+	result, err := m.validateRestart(channel)
 	if err != nil {
 		return xerrors.Errorf("failed to restart channel, validation error: %w", err)
 	}
@@ -52,7 +52,7 @@ func (m *manager) restartManagerPeerReceivePush(ctx context.Context, channel dat
 }
 
 func (m *manager) restartManagerPeerReceivePull(ctx context.Context, channel datatransfer.ChannelState) error {
-	result, err := m.revalidate(channel)
+	result, err := m.validateRestart(channel)
 	if err != nil {
 		return xerrors.Errorf("failed to restart channel, validation error: %w", err)
 	}

--- a/impl/restart_integration_test.go
+++ b/impl/restart_integration_test.go
@@ -135,8 +135,8 @@ func TestRestartPush(t *testing.T) {
 			// START DATA TRANSFER INSTANCES
 			rh.sv.ExpectSuccessPush()
 			rh.sv.StubResult(datatransfer.ValidationResult{Accepted: true})
-			rh.sv.ExpectSuccessRevalidation()
-			rh.sv.StubRevalidationResult(datatransfer.ValidationResult{Accepted: true})
+			rh.sv.ExpectSuccessValidateRestart()
+			rh.sv.StubRestartResult(datatransfer.ValidationResult{Accepted: true})
 
 			testutil.StartAndWaitForReady(rh.testCtx, t, rh.dt1)
 			testutil.StartAndWaitForReady(rh.testCtx, t, rh.dt2)
@@ -383,8 +383,8 @@ func TestRestartPull(t *testing.T) {
 			// START DATA TRANSFER INSTANCES
 			rh.sv.ExpectSuccessPull()
 			rh.sv.StubResult(datatransfer.ValidationResult{Accepted: true})
-			rh.sv.ExpectSuccessRevalidation()
-			rh.sv.StubRevalidationResult(datatransfer.ValidationResult{Accepted: true})
+			rh.sv.ExpectSuccessValidateRestart()
+			rh.sv.StubRestartResult(datatransfer.ValidationResult{Accepted: true})
 
 			testutil.StartAndWaitForReady(rh.testCtx, t, rh.dt1)
 			testutil.StartAndWaitForReady(rh.testCtx, t, rh.dt2)

--- a/manager.go
+++ b/manager.go
@@ -54,12 +54,12 @@ type RequestValidator interface {
 		baseCid cid.Cid,
 		selector ipld.Node) (ValidationResult, error)
 
-	// Revalidate revalidates a request with a new voucher
+	// ValidateRestart validates restarting a request
 	// -- All information about the validation operation is contained in ValidationResult,
 	// including if it was rejected. Information about why a rejection occurred should be embedded
 	// in the VoucherResult.
 	// -- error indicates something went wrong with the actual process of trying to validate
-	Revalidate(channelID ChannelID, channel ChannelState) (ValidationResult, error)
+	ValidateRestart(channelID ChannelID, channel ChannelState) (ValidationResult, error)
 }
 
 // TransportConfigurer provides a mechanism to provide transport specific configuration for a given voucher type
@@ -107,6 +107,10 @@ type Manager interface {
 
 	// send information from the responder to update the initiator on the state of their voucher
 	SendVoucherResult(ctx context.Context, chid ChannelID, voucher VoucherResult) error
+
+	// Update the validation status for a given channel, to change data limits, finalization, accepted status, and pause state
+	// and send new voucher results as
+	UpdateValidationStatus(ctx context.Context, chid ChannelID, validationResult ValidationResult) error
 
 	// close an open channel (effectively a cancel)
 	CloseDataTransferChannel(ctx context.Context, chid ChannelID) error

--- a/message/message.go
+++ b/message/message.go
@@ -11,6 +11,7 @@ var VoucherRequest = message1_1.VoucherRequest
 
 // DEPRECATED: Use ValidationResultResponse
 var RestartResponse = message1_1.RestartResponse
+
 var ValidationResultResponse = message1_1.ValidationResultResponse
 
 // DEPRECATED: Use ValidationResultResponse

--- a/message/message1_1prime/message.go
+++ b/message/message1_1prime/message.go
@@ -111,7 +111,8 @@ func ValidationResultResponse(
 	messageType types.MessageType,
 	id datatransfer.TransferID,
 	validationResult datatransfer.ValidationResult,
-	validationErr error) (datatransfer.Response, error) {
+	validationErr error,
+	paused bool) (datatransfer.Response, error) {
 	voucherResultType := datatransfer.EmptyTypeIdentifier
 	if validationResult.VoucherResult != nil {
 		voucherResultType = validationResult.VoucherResult.Type()
@@ -125,7 +126,7 @@ func ValidationResultResponse(
 		// Validation errors vs rejections
 		RequestAccepted:       validationErr == nil && validationResult.Accepted,
 		MessageType:           uint64(messageType),
-		Paused:                validationResult.LeaveRequestPaused,
+		Paused:                paused,
 		TransferId:            uint64(id),
 		VoucherTypeIdentifier: voucherResultType,
 		VoucherResultPtr:      &vnode,

--- a/network/libp2p_impl_test.go
+++ b/network/libp2p_impl_test.go
@@ -132,7 +132,7 @@ func TestMessageSendAndReceive(t *testing.T) {
 		accepted := false
 		id := datatransfer.TransferID(rand.Int31())
 		voucherResult := testutil.NewFakeDTType()
-		response, err := message.ValidationResultResponse(types.NewMessage, id, datatransfer.ValidationResult{Accepted: accepted, VoucherResult: voucherResult}, nil)
+		response, err := message.ValidationResultResponse(types.NewMessage, id, datatransfer.ValidationResult{Accepted: accepted, VoucherResult: voucherResult}, nil, false)
 		require.NoError(t, err)
 		require.NoError(t, dtnet2.SendMessage(ctx, host1.ID(), response))
 

--- a/testutil/stubbedvalidator.go
+++ b/testutil/stubbedvalidator.go
@@ -103,37 +103,37 @@ func (sv *StubbedValidator) VerifyExpectations(t *testing.T) {
 	}
 }
 
-func (sv *StubbedValidator) Revalidate(chid datatransfer.ChannelID, channelState datatransfer.ChannelState) (datatransfer.ValidationResult, error) {
+func (sv *StubbedValidator) ValidateRestart(chid datatransfer.ChannelID, channelState datatransfer.ChannelState) (datatransfer.ValidationResult, error) {
 	sv.didRevalidate = true
-	sv.RevalidationsReceived = append(sv.RevalidationsReceived, ReceivedRevalidation{chid, channelState})
+	sv.RevalidationsReceived = append(sv.RevalidationsReceived, ReceivedRestartValidation{chid, channelState})
 	return sv.revalidationResult, sv.revalidationError
 }
 
-// StubRevalidationResult returns the given voucher result when a call is made to Revalidate
-func (sv *StubbedValidator) StubRevalidationResult(voucherResult datatransfer.ValidationResult) {
+// StubRestartResult returns the given voucher result when a call is made to ValidateRestart
+func (sv *StubbedValidator) StubRestartResult(voucherResult datatransfer.ValidationResult) {
 	sv.revalidationResult = voucherResult
 }
 
-// StubErrorRevalidation sets Revalidate to error
-func (sv *StubbedValidator) StubErrorRevalidation() {
+// StubErrorValidateRestart sets ValidateRestart to error
+func (sv *StubbedValidator) StubErrorValidateRestart() {
 	sv.revalidationError = errors.New("something went wrong")
 }
 
-// StubSuccessRevalidation sets Revalidate to succeed
-func (sv *StubbedValidator) StubSuccessRevalidation() {
+// StubSuccessValidateRestart sets ValidateRestart to succeed
+func (sv *StubbedValidator) StubSuccessValidateRestart() {
 	sv.revalidationError = nil
 }
 
-// ExpectErrorRevalidation expects Revalidate to error
-func (sv *StubbedValidator) ExpectErrorRevalidation() {
+// ExpectErrorValidateRestart expects ValidateRestart to error
+func (sv *StubbedValidator) ExpectErrorValidateRestart() {
 	sv.expectRevalidate = true
-	sv.StubErrorRevalidation()
+	sv.StubErrorValidateRestart()
 }
 
-// ExpectSuccessRevalidation expects Revalidate to succeed
-func (sv *StubbedValidator) ExpectSuccessRevalidation() {
+// ExpectSuccessValidateRestart expects ValidateRestart to succeed
+func (sv *StubbedValidator) ExpectSuccessValidateRestart() {
 	sv.expectRevalidate = true
-	sv.StubSuccessRevalidation()
+	sv.StubSuccessValidateRestart()
 }
 
 // ReceivedValidation records a call to either ValidatePush or ValidatePull
@@ -145,8 +145,8 @@ type ReceivedValidation struct {
 	Selector ipld.Node
 }
 
-// ReceivedRevalidation records a call to Revalidate
-type ReceivedRevalidation struct {
+// ReceivedRestartValidation records a call to ValidateRestart
+type ReceivedRestartValidation struct {
 	ChannelID    datatransfer.ChannelID
 	ChannelState datatransfer.ChannelState
 }
@@ -165,7 +165,7 @@ type StubbedValidator struct {
 	pullError             error
 	revalidationError     error
 	ValidationsReceived   []ReceivedValidation
-	RevalidationsReceived []ReceivedRevalidation
+	RevalidationsReceived []ReceivedRestartValidation
 }
 
 var _ datatransfer.RequestValidator = (*StubbedValidator)(nil)


### PR DESCRIPTION
# Goals

This PR was written during the course of implementing the voucher refactor in go-fil-markets. 

# Implementation

The main goal in refactoring the go-fil-markets retrieval provider was to drive towards clear, easy to reason about logic with very clear event structure and idempotent code that restarts easily.

What became clear is that fundamentally, voucher revalidation needs to happen asynchronously. So now, the consuming library simply monitors data transfer events and updates validation status as new vouchers come in. We changed Revalidate to ValidateRestart -- so that it only covers restarts, while removing synchronous revalidation entirely. Now, we simply save new vouchers, and we've added an UpdateValidationStatus method to change validation parameters when the markets software processes all vouchers.

Moreover, the idea of Pausing in validation needs to be separated from DataLimits and Finalization. The way to unpause a request held on a data limit is to increase the data limit. The way to end finalization is to set RequiresFinalization to false. The pause property is renamed from LeaveRequestPaused to ForcePause, clearly identifying that the markets library is explicitly applying it's own logic around pausing -- in this case, pausing to Unseal.

Finally I did a minor reorderng of validation events to promote more predictable behavior near the end of a transfer (not accidentally completing the channel before events get processed)
