### PR TITLE
Do not EncodeToNode selectors

### DIFF
--- a/message/message1_1prime/message.go
+++ b/message/message1_1prime/message.go
@@ -27,11 +27,6 @@ func NewRequest(id datatransfer.TransferID, isRestart bool, isPull bool, vtype d
 		return nil, xerrors.Errorf("base CID must be defined")
 	}
 
-	selnode, err := encoding.EncodeToNode(selector)
-	if err != nil {
-		return nil, xerrors.Errorf("Creating request: %w", err)
-	}
-
 	var typ uint64
 	if isRestart {
 		typ = uint64(types.RestartMessage)
@@ -43,7 +38,7 @@ func NewRequest(id datatransfer.TransferID, isRestart bool, isPull bool, vtype d
 		MessageType:           typ,
 		Pull:                  isPull,
 		VoucherPtr:            &vnode,
-		SelectorPtr:           &selnode,
+		SelectorPtr:           &selector,
 		BaseCidPtr:            &baseCid,
 		VoucherTypeIdentifier: vtype,
 		TransferId:            uint64(id),


### PR DESCRIPTION
# Goals

Cut down memory usage -- see here from a recent test in AutoRetrieve:
![profile001](https://user-images.githubusercontent.com/1450680/169654677-fb94efb4-8879-4b89-917a-1f70244d9128.svg)

Looks like our EncodeToNode function is eating memory (somewhat predictably since we knew it was a hack). However, on the graph 1.35GB is going through https://github.com/filecoin-project/go-data-transfer/blob/master/message/message1_1prime/message.go#L30, which is an EncodeToNode call on a selector. Given a selector is already an ipld.Node, we don't need this.

# Implementation

Remove round trip for selector.