### PR TITLE
Fix transfer message bindnode wrap passing pointer to pointer

### DIFF
--- a/message/message1_1prime/transfer_message.go
+++ b/message/message1_1prime/transfer_message.go
@@ -30,7 +30,7 @@ func (tm *TransferMessage1_1) TransferID() datatransfer.TransferID {
 }
 
 func (tm *TransferMessage1_1) toIPLD() schema.TypedNode {
-	return bindnode.Wrap(&tm, Prototype.TransferMessage.Type())
+	return bindnode.Wrap(tm, Prototype.TransferMessage.Type())
 }
 
 // ToNet serializes a transfer message type.


### PR DESCRIPTION
Bindnode wrap expects a pointer. A fail-fast check is introduced in
ipld/go-ipld-prime#427 which will cause a panic if the IPLD dependency
is upgraded to the head of main branch.

Avoid passing pointer-to-pointer when wrapping transfer message.

See:
- https://github.com/ipld/go-ipld-prime/pull/427