### PR TITLE
Fix close functions

### DIFF
--- a/channels/channel_state.go
+++ b/channels/channel_state.go
@@ -158,6 +158,10 @@ func (c channelState) SelfPaused() bool {
 	return c.ResponderPaused()
 }
 
+func (c channelState) TransferClosed() bool {
+	return c.ic.TransferClosed
+}
+
 // Stages returns the current ChannelStages object, or an empty object.
 // It is unsafe for the caller to modify the return value, and changes may not
 // be persisted. It should be treated as immutable.

--- a/channels/channels.go
+++ b/channels/channels.go
@@ -306,6 +306,11 @@ func (c *Channels) SetRequiresFinalization(chid datatransfer.ChannelID, Requires
 	return c.send(chid, datatransfer.SetRequiresFinalization, RequiresFinalization)
 }
 
+// CloseTransfer indicates the transfer is closed, even if the transfer was not finished
+func (c *Channels) CloseTransfer(chid datatransfer.ChannelID) error {
+	return c.send(chid, datatransfer.CloseTransfer)
+}
+
 // HasChannel returns true if the given channel id is being tracked
 func (c *Channels) HasChannel(chid datatransfer.ChannelID) (bool, error) {
 	return c.stateMachines.Has(chid)

--- a/channels/channels_fsm.go
+++ b/channels/channels_fsm.go
@@ -46,6 +46,7 @@ var ChannelEvents = fsm.Events{
 	}),
 
 	fsm.Event(datatransfer.Cancel).FromAny().To(datatransfer.Cancelling).Action(func(chst *internal.ChannelState) error {
+		chst.TransferClosed = true
 		chst.AddLog("")
 		return nil
 	}),
@@ -145,6 +146,7 @@ var ChannelEvents = fsm.Events{
 
 	fsm.Event(datatransfer.Error).FromAny().To(datatransfer.Failing).Action(func(chst *internal.ChannelState, err error) error {
 		chst.Message = err.Error()
+		chst.TransferClosed = true
 		chst.AddLog("data transfer erred: %s", chst.Message)
 		return nil
 	}),
@@ -224,6 +226,7 @@ var ChannelEvents = fsm.Events{
 		// the finalization process and complete the transfer
 		From(datatransfer.AwaitingAcceptance).To(datatransfer.Completing).
 		Action(func(chst *internal.ChannelState) error {
+			chst.TransferClosed = true
 			chst.AddLog("")
 			return nil
 		}),
@@ -248,12 +251,20 @@ var ChannelEvents = fsm.Events{
 	}),
 
 	fsm.Event(datatransfer.BeginFinalizing).FromAny().To(datatransfer.Finalizing).Action(func(chst *internal.ChannelState) error {
+		chst.TransferClosed = true
+		chst.AddLog("")
+		return nil
+	}),
+
+	fsm.Event(datatransfer.CloseTransfer).FromAny().ToJustRecord().Action(func(chst *internal.ChannelState) error {
+		chst.TransferClosed = true
 		chst.AddLog("")
 		return nil
 	}),
 
 	// Both the local node and the remote peer have completed the transfer
 	fsm.Event(datatransfer.Complete).FromAny().To(datatransfer.Completing).Action(func(chst *internal.ChannelState) error {
+		chst.TransferClosed = true
 		chst.AddLog("")
 		return nil
 	}),

--- a/channels/channels_test.go
+++ b/channels/channels_test.go
@@ -440,6 +440,15 @@ func TestMigrations(t *testing.T) {
 		datatransfer.ResponderPaused,
 		datatransfer.BothPaused,
 		datatransfer.Ongoing,
+		datatransfer.TransferFinished,
+		datatransfer.ResponderFinalizingTransferFinished,
+		datatransfer.Finalizing,
+		datatransfer.Completed,
+		datatransfer.Completing,
+		datatransfer.Failing,
+		datatransfer.Failed,
+		datatransfer.Cancelling,
+		datatransfer.Cancelled,
 	}
 	for i := 0; i < numChannels; i++ {
 		transferIDs[i] = datatransfer.TransferID(rand.Uint64())
@@ -515,8 +524,9 @@ func TestMigrations(t *testing.T) {
 		datatransfer.Ongoing,
 	}
 
-	expectedInitiatorPaused := []bool{false, true, false, true, false}
-	expectedResponderPaused := []bool{false, false, true, true, false}
+	expectedInitiatorPaused := []bool{false, true, false, true, false, false, false, false, false, false, false, false, false, false}
+	expectedResponderPaused := []bool{false, false, true, true, false, false, false, false, false, false, false, false, false, false}
+	expectedTransferClosed := []bool{false, false, false, false, false, true, true, true, true, true, true, true, true, true}
 	for i := 0; i < numChannels; i++ {
 
 		channel, err := channelList.GetByID(ctx, datatransfer.ChannelID{
@@ -540,10 +550,10 @@ func TestMigrations(t *testing.T) {
 		require.Equal(t, expectedStatuses[i], channel.Status())
 		require.Equal(t, expectedInitiatorPaused[i], channel.InitiatorPaused())
 		require.Equal(t, expectedResponderPaused[i], channel.ResponderPaused())
+		require.Equal(t, expectedTransferClosed[i], channel.TransferClosed())
 		require.Equal(t, basicnode.NewInt(sentIndex[i]), channel.SentIndex())
 		require.Equal(t, basicnode.NewInt(receivedIndex[i]), channel.ReceivedIndex())
 		require.Equal(t, basicnode.NewInt(queuedIndex[i]), channel.QueuedIndex())
-
 	}
 }
 

--- a/channels/internal/internalchannel.go
+++ b/channels/internal/internalchannel.go
@@ -121,6 +121,8 @@ type ChannelState struct {
 	ResponderPaused bool
 	// InitiatorPaused indicates whether the initiator is in a paused state
 	InitiatorPaused bool
+	// TransferClosed indicates the transfer portion of the request is over
+	TransferClosed bool
 	// Stages traces the execution fo a data transfer.
 	//
 	// EXPERIMENTAL; subject to change.

--- a/channels/internal/internalchannel_cbor_gen.go
+++ b/channels/internal/internalchannel_cbor_gen.go
@@ -23,7 +23,7 @@ func (t *ChannelState) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{184, 24}); err != nil {
+	if _, err := w.Write([]byte{184, 25}); err != nil {
 		return err
 	}
 
@@ -457,6 +457,22 @@ func (t *ChannelState) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
+	// t.TransferClosed (bool) (bool)
+	if len("TransferClosed") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"TransferClosed\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("TransferClosed"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("TransferClosed")); err != nil {
+		return err
+	}
+
+	if err := cbg.WriteBool(w, t.TransferClosed); err != nil {
+		return err
+	}
+
 	// t.Stages (datatransfer.ChannelStages) (struct)
 	if len("Stages") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"Stages\" was too long")
@@ -843,6 +859,24 @@ func (t *ChannelState) UnmarshalCBOR(r io.Reader) error {
 				t.InitiatorPaused = false
 			case 21:
 				t.InitiatorPaused = true
+			default:
+				return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+			}
+			// t.TransferClosed (bool) (bool)
+		case "TransferClosed":
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+			if maj != cbg.MajOther {
+				return fmt.Errorf("booleans must be major type 7")
+			}
+			switch extra {
+			case 20:
+				t.TransferClosed = false
+			case 21:
+				t.TransferClosed = true
 			default:
 				return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
 			}

--- a/events.go
+++ b/events.go
@@ -129,6 +129,9 @@ const (
 
 	// SendMessageError indicates an error sending a data transfer message
 	SendMessageError
+
+	// CloseTransfer is called indicates the transfer is complete, but not because it was finished
+	CloseTransfer
 )
 
 // Events are human readable names for data transfer events
@@ -169,6 +172,7 @@ var Events = map[EventCode]string{
 	DataLimitExceeded:           "DataLimitExceeded",
 	TransferInitiated:           "TransferInitiated",
 	SendMessageError:            "SendMessageError",
+	CloseTransfer:               "CloseTransfer",
 }
 
 // Event is a struct containing information about a data transfer event

--- a/impl/events.go
+++ b/impl/events.go
@@ -168,7 +168,7 @@ func (m *manager) channelCompleted(chid datatransfer.ChannelID, success bool, er
 	// If the transferred errored on completion
 	if !success {
 		// send an error, but only if we haven't already errored/finished transfer already for some reason
-		if !chst.Status().TransferComplete() {
+		if !chst.TransferClosed() {
 			err := fmt.Errorf("data transfer channel %s failed to transfer data: %s", chid, errorMessage)
 			log.Warnf(err.Error())
 			return m.channels.Error(chid, err)

--- a/impl/initiating_test.go
+++ b/impl/initiating_test.go
@@ -191,7 +191,7 @@ func TestDataTransferInitiating(t *testing.T) {
 			},
 		},
 		"close push request": {
-			expectedEvents: []datatransfer.EventCode{datatransfer.Open, datatransfer.Cancel, datatransfer.CleanupComplete},
+			expectedEvents: []datatransfer.EventCode{datatransfer.Open, datatransfer.CloseTransfer, datatransfer.Cancel, datatransfer.CleanupComplete},
 			verify: func(t *testing.T, h *harness) {
 				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
 				require.NoError(t, err)
@@ -247,7 +247,7 @@ func TestDataTransferInitiating(t *testing.T) {
 			},
 		},
 		"close pull request": {
-			expectedEvents: []datatransfer.EventCode{datatransfer.Open, datatransfer.Cancel, datatransfer.CleanupComplete},
+			expectedEvents: []datatransfer.EventCode{datatransfer.Open, datatransfer.CloseTransfer, datatransfer.Cancel, datatransfer.CleanupComplete},
 			verify: func(t *testing.T, h *harness) {
 				channelID, err := h.dt.OpenPullDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
 				require.NoError(t, err)

--- a/itest/integration_test.go
+++ b/itest/integration_test.go
@@ -725,6 +725,11 @@ func TestAutoRestart(t *testing.T) {
 				// Watch for successful completion
 				finished := make(chan struct{}, 2)
 				var subscriber datatransfer.Subscriber = func(event datatransfer.Event, channelState datatransfer.ChannelState) {
+					if channelState.ChannelID().Initiator == channelState.SelfPeer() {
+						t.Logf("Initiator Event: %s, Status: %s", datatransfer.Events[event.Code], datatransfer.Statuses[channelState.Status()])
+					} else {
+						t.Logf("Responder Event: %s, Status: %s", datatransfer.Events[event.Code], datatransfer.Statuses[channelState.Status()])
+					}
 					if channelState.Status() == datatransfer.Completed {
 						finished <- struct{}{}
 					}
@@ -1161,9 +1166,11 @@ func TestRoundTripCancelledRequest(t *testing.T) {
 							case <-ctx.Done():
 							case <-timer.C:
 								if data.isPull {
-									_ = dt1.CloseDataTransferChannel(ctx, chid)
+									err = dt1.CloseDataTransferChannel(ctx, chid)
+									require.NoError(t, err)
 								} else {
-									_ = dt2.CloseDataTransferChannel(ctx, chid)
+									err = dt2.CloseDataTransferChannel(ctx, chid)
+									require.NoError(t, err)
 								}
 							}
 						}()

--- a/statuses.go
+++ b/statuses.go
@@ -109,23 +109,6 @@ func (s Status) InFinalization() bool {
 	return FinalizationStatuses.Contains(s)
 }
 
-var TransferCompleteStates = statusList{
-	TransferFinished,
-	ResponderFinalizingTransferFinished,
-	Finalizing,
-	Completed,
-	Completing,
-	Failing,
-	Failed,
-	Cancelling,
-	Cancelled,
-	ChannelNotFoundError,
-}
-
-func (s Status) TransferComplete() bool {
-	return TransferCompleteStates.Contains(s)
-}
-
 var TransferringStates = statusList{
 	Ongoing,
 	ResponderCompleted,

--- a/testutil/mockchannelstate.go
+++ b/testutil/mockchannelstate.go
@@ -250,3 +250,7 @@ func (m *MockChannelState) SelfPaused() bool {
 	}
 	return m.responderPaused
 }
+
+func (m *MockChannelState) TransferClosed() bool {
+	return false
+}

--- a/transport/graphsync/dtchannel/dtchannel.go
+++ b/transport/graphsync/dtchannel/dtchannel.go
@@ -362,7 +362,7 @@ func (c *Channel) ActionFromChannelState(chst datatransfer.ChannelState) Action 
 
 func (c *Channel) actionFromChannelState(chst datatransfer.ChannelState) Action {
 	// if the state is closed, and we haven't closed, we need to close
-	if !c.requesterCancelled && c.state != channelClosed && chst.Status().TransferComplete() {
+	if !c.requesterCancelled && c.state != channelClosed && chst.TransferClosed() {
 		return Close
 	}
 

--- a/transport/graphsync/graphsync.go
+++ b/transport/graphsync/graphsync.go
@@ -282,13 +282,13 @@ func (t *Transport) CleanupChannel(chid datatransfer.ChannelID) {
 
 	t.dtChannelsLk.Unlock()
 
-	// Clean up mapping from gs key to channel ID
-	t.requestIDToChannelID.deleteRefs(chid)
-
 	// Clean up the channel
 	if ok {
 		ch.Cleanup()
 	}
+
+	// Clean up mapping from gs key to channel ID
+	t.requestIDToChannelID.deleteRefs(chid)
 
 	t.dtNet.Unprotect(t.otherPeer(chid), chid.String())
 }

--- a/types.go
+++ b/types.go
@@ -158,6 +158,9 @@ type ChannelState interface {
 	// SelfPaused indicates whether the local peer for this channel is in a paused state
 	SelfPaused() bool
 
+	// TransferClosed indicates whether the transfer has finished
+	TransferClosed() bool
+
 	// Stages returns the timeline of events this data transfer has gone through,
 	// for observability purposes.
 	//


### PR DESCRIPTION
# Goals

fix close functions post v2 upgrade

# Implementation

- Switch from checking status for transfer complete in transport as an indicator of a closed transfer to checking a direct function on channel state: TransferClosed()
- Have existing transfer closing events set the transfer to be closed
- Add an additional event, CloseTransfer, that dispatches to simply mark the transfer as closed without changing status
- Have the closing functions only call CloseTransfer before actually updating the transport, and then call the final termination functions afterward.