### PR TITLE
fix: provide a reverse name mapping for Opened event

### DIFF
--- a/events.go
+++ b/events.go
@@ -144,6 +144,7 @@ var Events = map[EventCode]string{
 	ReceiveDataError:            "ReceiveDataError",
 	TransferRequestQueued:       "TransferRequestQueued",
 	RequestCancelled:            "RequestCancelled",
+	Opened:                      "Opened",
 }
 
 // Event is a struct containing information about a data transfer event


### PR DESCRIPTION
seen during logging, event name = `""`