### PR TITLE
docs(README): update installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This module encapsulates protocols for exchanging piece data between storage cli
 
 **Requires go 1.13**
 
-Install the module in your package or app with `go get "github.com/filecoin-project/go-data-transfer/v2/datatransfer"`
+Install the module in your package or app with `go get "github.com/filecoin-project/go-data-transfer/v2"`
 
 
 ### Initialize a data transfer module


### PR DESCRIPTION
Running the installation command in the README gave me the following output without actually downloading the new module.
```
$ go get github.com/filecoin-project/go-data-transfer/v2/datatransfer
go: downloading github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc1
go: module github.com/filecoin-project/go-data-transfer/v2@upgrade found (v2.0.0-rc1), but does not contain package github.com/filecoin-project/go-data-transfer/v2/datatransfer
```

Running the following updated command ran successfully.
```
$ go get github.com/filecoin-project/go-data-transfer/v2
go: downloading github.com/ipfs/go-graphsync v0.14.0
go: added github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc1
go: upgraded github.com/ipfs/go-graphsync v0.13.2 => v0.14.0
```

**Go Version:** 1.19.3 linux/amd64