### PR TITLE
feat: per transfer events callback

### DIFF
--- a/impl/initiating_test.go
+++ b/impl/initiating_test.go
@@ -34,7 +34,7 @@ func TestDataTransferInitiating(t *testing.T) {
 		"OpenPushDataTransfer": {
 			expectedEvents: []datatransfer.EventCode{datatransfer.Open},
 			verify: func(t *testing.T, h *harness) {
-				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, channelID)
 				require.Equal(t, channelID.Initiator, h.peers[0])
@@ -59,7 +59,7 @@ func TestDataTransferInitiating(t *testing.T) {
 		"OpenPullDataTransfer": {
 			expectedEvents: []datatransfer.EventCode{datatransfer.Open},
 			verify: func(t *testing.T, h *harness) {
-				channelID, err := h.dt.OpenPullDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPullDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, channelID)
 				require.Equal(t, channelID.Initiator, h.peers[0])
@@ -92,7 +92,7 @@ func TestDataTransferInitiating(t *testing.T) {
 		"SendVoucher with channel open, push succeeds": {
 			expectedEvents: []datatransfer.EventCode{datatransfer.Open, datatransfer.NewVoucher},
 			verify: func(t *testing.T, h *harness) {
-				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				voucher := testutil.NewTestTypedVoucher()
 				err = h.dt.SendVoucher(ctx, channelID, voucher)
@@ -110,7 +110,7 @@ func TestDataTransferInitiating(t *testing.T) {
 		"SendVoucher with channel open, pull succeeds": {
 			expectedEvents: []datatransfer.EventCode{datatransfer.Open, datatransfer.NewVoucher},
 			verify: func(t *testing.T, h *harness) {
-				channelID, err := h.dt.OpenPullDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPullDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				voucher := testutil.NewTestTypedVoucher()
 				err = h.dt.SendVoucher(ctx, channelID, voucher)
@@ -138,7 +138,7 @@ func TestDataTransferInitiating(t *testing.T) {
 		"success response": {
 			expectedEvents: []datatransfer.EventCode{datatransfer.Open, datatransfer.Accept, datatransfer.ResumeResponder},
 			verify: func(t *testing.T, h *harness) {
-				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, channelID)
 				response, err := message.NewResponse(channelID.ID, true, false, nil)
@@ -150,7 +150,7 @@ func TestDataTransferInitiating(t *testing.T) {
 		"success response, w/ voucher result": {
 			expectedEvents: []datatransfer.EventCode{datatransfer.Open, datatransfer.NewVoucherResult, datatransfer.Accept, datatransfer.ResumeResponder},
 			verify: func(t *testing.T, h *harness) {
-				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, channelID)
 				response, err := message.NewResponse(channelID.ID, true, false, &h.voucherResult)
@@ -162,7 +162,7 @@ func TestDataTransferInitiating(t *testing.T) {
 		"push request, pause behavior": {
 			expectedEvents: []datatransfer.EventCode{datatransfer.Open, datatransfer.Accept, datatransfer.ResumeResponder, datatransfer.PauseInitiator, datatransfer.ResumeInitiator},
 			verify: func(t *testing.T, h *harness) {
-				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, channelID)
 				response, err := message.NewResponse(channelID.ID, true, false, nil)
@@ -196,7 +196,7 @@ func TestDataTransferInitiating(t *testing.T) {
 		"close push request": {
 			expectedEvents: []datatransfer.EventCode{datatransfer.Open, datatransfer.Cancel, datatransfer.CleanupComplete},
 			verify: func(t *testing.T, h *harness) {
-				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, channelID)
 				err = h.dt.CloseDataTransferChannel(h.ctx, channelID)
@@ -218,7 +218,7 @@ func TestDataTransferInitiating(t *testing.T) {
 		"pull request, pause behavior": {
 			expectedEvents: []datatransfer.EventCode{datatransfer.Open, datatransfer.Accept, datatransfer.ResumeResponder, datatransfer.PauseInitiator, datatransfer.ResumeInitiator},
 			verify: func(t *testing.T, h *harness) {
-				channelID, err := h.dt.OpenPullDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPullDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, channelID)
 				response, err := message.NewResponse(channelID.ID, true, false, nil)
@@ -252,7 +252,7 @@ func TestDataTransferInitiating(t *testing.T) {
 		"close pull request": {
 			expectedEvents: []datatransfer.EventCode{datatransfer.Open, datatransfer.Cancel, datatransfer.CleanupComplete},
 			verify: func(t *testing.T, h *harness) {
-				channelID, err := h.dt.OpenPullDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPullDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, channelID)
 				err = h.dt.CloseDataTransferChannel(h.ctx, channelID)
@@ -283,7 +283,7 @@ func TestDataTransferInitiating(t *testing.T) {
 					ft.RecordCustomizedTransfer(channelID, voucher)
 				})
 				require.NoError(t, err)
-				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, channelID)
 				require.Len(t, h.transport.CustomizedTransfers, 1)
@@ -303,7 +303,7 @@ func TestDataTransferInitiating(t *testing.T) {
 					ft.RecordCustomizedTransfer(channelID, voucher)
 				})
 				require.NoError(t, err)
-				channelID, err := h.dt.OpenPullDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPullDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, channelID)
 				require.Len(t, h.transport.CustomizedTransfers, 1)
@@ -356,7 +356,7 @@ func TestDataTransferRestartInitiating(t *testing.T) {
 			expectedEvents: []datatransfer.EventCode{datatransfer.Open, datatransfer.TransferInitiated, datatransfer.DataReceivedProgress, datatransfer.DataReceived, datatransfer.DataReceivedProgress, datatransfer.DataReceived},
 			verify: func(t *testing.T, h *harness) {
 				// open a pull channel
-				channelID, err := h.dt.OpenPullDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPullDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, channelID)
 				require.Len(t, h.transport.OpenedChannels, 1)
@@ -403,7 +403,7 @@ func TestDataTransferRestartInitiating(t *testing.T) {
 			expectedEvents: []datatransfer.EventCode{datatransfer.Open},
 			verify: func(t *testing.T, h *harness) {
 				// open a push channel
-				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, channelID)
 				require.Len(t, h.transport.OpenedChannels, 0)

--- a/impl/responding_test.go
+++ b/impl/responding_test.go
@@ -699,7 +699,7 @@ func TestDataTransferRestartResponding(t *testing.T) {
 		"receiving a pull restart response": {
 			expectedEvents: []datatransfer.EventCode{datatransfer.Open, datatransfer.Restart, datatransfer.ResumeResponder},
 			verify: func(t *testing.T, h *receiverHarness) {
-				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, channelID)
 
@@ -980,7 +980,7 @@ func TestDataTransferRestartResponding(t *testing.T) {
 			},
 			verify: func(t *testing.T, h *receiverHarness) {
 				// create an outgoing pull channel first
-				channelID, err := h.dt.OpenPullDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPullDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, channelID)
 
@@ -1034,7 +1034,7 @@ func TestDataTransferRestartResponding(t *testing.T) {
 			},
 			verify: func(t *testing.T, h *receiverHarness) {
 				// create an outgoing push request first
-				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, channelID)
 
@@ -1097,7 +1097,7 @@ func TestDataTransferRestartResponding(t *testing.T) {
 			verify: func(t *testing.T, h *receiverHarness) {
 				// create an outgoing push request first
 				p := testutil.GeneratePeers(1)[0]
-				channelID, err := h.dt.OpenPushDataChannel(h.ctx, p, h.voucher, h.baseCid, h.stor)
+				channelID, err := h.dt.OpenPushDataChannel(h.ctx, p, h.voucher, h.baseCid, h.stor, nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, channelID)
 

--- a/itest/integration_test.go
+++ b/itest/integration_test.go
@@ -226,11 +226,11 @@ func TestRoundTrip(t *testing.T) {
 				if data.isPull {
 					sv.ExpectSuccessPull()
 					require.NoError(t, dt1.RegisterVoucherType(testutil.TestVoucherType, sv))
-					chid, err = dt2.OpenPullDataChannel(ctx, host1.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+					chid, err = dt2.OpenPullDataChannel(ctx, host1.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 				} else {
 					sv.ExpectSuccessPush()
 					require.NoError(t, dt2.RegisterVoucherType(testutil.TestVoucherType, sv))
-					chid, err = dt1.OpenPushDataChannel(ctx, host2.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+					chid, err = dt1.OpenPushDataChannel(ctx, host2.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 				}
 				require.NoError(t, err)
 				opens := 0
@@ -357,14 +357,14 @@ func TestMultipleRoundTripMultipleStores(t *testing.T) {
 				sv.ExpectSuccessPull()
 				require.NoError(t, dt1.RegisterVoucherType(testutil.TestVoucherType, sv))
 				for i := 0; i < data.requestCount; i++ {
-					_, err = dt2.OpenPullDataChannel(ctx, host1.ID(), vouchers[i], rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+					_, err = dt2.OpenPullDataChannel(ctx, host1.ID(), vouchers[i], rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 					require.NoError(t, err)
 				}
 			} else {
 				sv.ExpectSuccessPush()
 				require.NoError(t, dt2.RegisterVoucherType(testutil.TestVoucherType, sv))
 				for i := 0; i < data.requestCount; i++ {
-					_, err = dt1.OpenPushDataChannel(ctx, host2.ID(), vouchers[i], rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+					_, err = dt1.OpenPushDataChannel(ctx, host2.ID(), vouchers[i], rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 					require.NoError(t, err)
 				}
 			}
@@ -491,14 +491,14 @@ func TestManyReceiversAtOnce(t *testing.T) {
 				sv.ExpectSuccessPull()
 				require.NoError(t, dt1.RegisterVoucherType(testutil.TestVoucherType, sv))
 				for i, receiver := range receivers {
-					_, err = receiver.OpenPullDataChannel(ctx, host1.ID(), vouchers[i], rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+					_, err = receiver.OpenPullDataChannel(ctx, host1.ID(), vouchers[i], rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 					require.NoError(t, err)
 				}
 			} else {
 				sv.ExpectSuccessPush()
 				for i, receiver := range receivers {
 					require.NoError(t, receiver.RegisterVoucherType(testutil.TestVoucherType, sv))
-					_, err = dt1.OpenPushDataChannel(ctx, hosts[i].ID(), vouchers[i], rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+					_, err = dt1.OpenPushDataChannel(ctx, hosts[i].ID(), vouchers[i], rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 					require.NoError(t, err)
 				}
 			}
@@ -764,10 +764,10 @@ func TestAutoRestart(t *testing.T) {
 				var chid datatransfer.ChannelID
 				if tc.isPush {
 					// Open a push channel
-					chid, err = initiator.OpenPushDataChannel(ctx, responderHost.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+					chid, err = initiator.OpenPushDataChannel(ctx, responderHost.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 				} else {
 					// Open a pull channel
-					chid, err = initiator.OpenPullDataChannel(ctx, responderHost.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+					chid, err = initiator.OpenPullDataChannel(ctx, responderHost.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 				}
 				require.NoError(t, err)
 
@@ -941,10 +941,10 @@ func TestAutoRestartAfterBouncingInitiator(t *testing.T) {
 		var chid datatransfer.ChannelID
 		if isPush {
 			// Open a push channel
-			chid, err = initiator.OpenPushDataChannel(ctx, responderHost.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+			chid, err = initiator.OpenPushDataChannel(ctx, responderHost.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 		} else {
 			// Open a pull channel
-			chid, err = initiator.OpenPullDataChannel(ctx, responderHost.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+			chid, err = initiator.OpenPullDataChannel(ctx, responderHost.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 		}
 		require.NoError(t, err)
 
@@ -1126,12 +1126,12 @@ func TestRoundTripCancelledRequest(t *testing.T) {
 				sv.ExpectSuccessPull()
 				sv.StubResult(datatransfer.ValidationResult{Accepted: true, ForcePause: true})
 				require.NoError(t, dt1.RegisterVoucherType(testutil.TestVoucherType, sv))
-				chid, err = dt2.OpenPullDataChannel(ctx, host1.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+				chid, err = dt2.OpenPullDataChannel(ctx, host1.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 			} else {
 				sv.ExpectSuccessPush()
 				sv.StubResult(datatransfer.ValidationResult{Accepted: true, ForcePause: true})
 				require.NoError(t, dt2.RegisterVoucherType(testutil.TestVoucherType, sv))
-				chid, err = dt1.OpenPushDataChannel(ctx, host2.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+				chid, err = dt1.OpenPushDataChannel(ctx, host2.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 			}
 			require.NoError(t, err)
 			opens := 0
@@ -1384,7 +1384,7 @@ func TestSimulatedRetrievalFlow(t *testing.T) {
 
 			require.NoError(t, dt1.RegisterVoucherType(testutil.TestVoucherType, sv))
 
-			chid, err = dt2.OpenPullDataChannel(ctx, host1.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+			chid, err = dt2.OpenPullDataChannel(ctx, host1.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 			require.NoError(t, err)
 
 			for providerFinished != nil || clientFinished != nil {
@@ -1512,11 +1512,11 @@ func TestPauseAndResume(t *testing.T) {
 			if isPull {
 				sv.ExpectSuccessPull()
 				require.NoError(t, dt1.RegisterVoucherType(testutil.TestVoucherType, sv))
-				chid, err = dt2.OpenPullDataChannel(ctx, host1.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+				chid, err = dt2.OpenPullDataChannel(ctx, host1.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 			} else {
 				sv.ExpectSuccessPush()
 				require.NoError(t, dt2.RegisterVoucherType(testutil.TestVoucherType, sv))
-				chid, err = dt1.OpenPushDataChannel(ctx, host2.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+				chid, err = dt1.OpenPushDataChannel(ctx, host2.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 			}
 			require.NoError(t, err)
 			opens := 0
@@ -1610,9 +1610,9 @@ func TestUnrecognizedVoucherRoundTrip(t *testing.T) {
 			rootCid := root.(cidlink.Link).Cid
 
 			if isPull {
-				_, err = dt2.OpenPullDataChannel(ctx, host1.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+				_, err = dt2.OpenPullDataChannel(ctx, host1.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 			} else {
-				_, err = dt1.OpenPushDataChannel(ctx, host2.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+				_, err = dt1.OpenPushDataChannel(ctx, host2.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 			}
 			require.NoError(t, err)
 			opens := 0
@@ -1675,7 +1675,7 @@ func TestDataTransferSubscribing(t *testing.T) {
 	}
 	unsub1 := dt1.SubscribeToEvents(subscribe1)
 	unsub2 := dt1.SubscribeToEvents(subscribe2)
-	_, err = dt1.OpenPushDataChannel(ctx, host2.ID(), voucher, baseCid, selectorparse.CommonSelector_ExploreAllRecursively)
+	_, err = dt1.OpenPushDataChannel(ctx, host2.ID(), voucher, baseCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 	require.NoError(t, err)
 	select {
 	case <-ctx.Done():
@@ -1704,7 +1704,7 @@ func TestDataTransferSubscribing(t *testing.T) {
 	}
 	unsub3 := dt1.SubscribeToEvents(subscribe3)
 	unsub4 := dt1.SubscribeToEvents(subscribe4)
-	_, err = dt1.OpenPullDataChannel(ctx, host2.ID(), voucher, baseCid, selectorparse.CommonSelector_ExploreAllRecursively)
+	_, err = dt1.OpenPullDataChannel(ctx, host2.ID(), voucher, baseCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 	require.NoError(t, err)
 	select {
 	case <-ctx.Done():
@@ -1797,7 +1797,7 @@ func TestRespondingToPushGraphsyncRequests(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("when request is initiated", func(t *testing.T) {
-		_, err := dt1.OpenPushDataChannel(ctx, host2.ID(), voucher, link.(cidlink.Link).Cid, selectorparse.CommonSelector_ExploreAllRecursively)
+		_, err := dt1.OpenPushDataChannel(ctx, host2.ID(), voucher, link.(cidlink.Link).Cid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 		require.NoError(t, err)
 
 		var messageReceived receivedMessage
@@ -1880,7 +1880,7 @@ func TestResponseHookWhenExtensionNotFound(t *testing.T) {
 		}
 		gs1.RegisterIncomingRequestHook(validateHook)
 
-		_, err := dt1.OpenPushDataChannel(ctx, host2.ID(), voucher, link.(cidlink.Link).Cid, selectorparse.CommonSelector_ExploreAllRecursively)
+		_, err := dt1.OpenPushDataChannel(ctx, host2.ID(), voucher, link.(cidlink.Link).Cid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 		require.NoError(t, err)
 
 		select {
@@ -2112,7 +2112,7 @@ func TestMultipleMessagesInExtension(t *testing.T) {
 	require.NoError(t, dt1.RegisterVoucherType(testutil.TestVoucherType, sv))
 
 	voucher := testutil.NewTestTypedVoucherWith("applesauce")
-	chid, err = dt2.OpenPullDataChannel(ctx, host1.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+	chid, err = dt2.OpenPullDataChannel(ctx, host1.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 	require.NoError(t, err)
 
 	// Expect the client to receive a response voucher, the provider to complete the transfer and
@@ -2242,7 +2242,7 @@ func TestMultipleParallelTransfers(t *testing.T) {
 			rootCid := root.(cidlink.Link).Cid
 
 			voucher := testutil.NewTestTypedVoucher()
-			chid, err = dt2.OpenPullDataChannel(ctx, host1.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+			chid, err = dt2.OpenPullDataChannel(ctx, host1.ID(), voucher, rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 			require.NoError(t, err)
 			close(chidReceived)
 			// Expect the client to receive a response voucher, the provider to complete the transfer and

--- a/itest/restart_integration_test.go
+++ b/itest/restart_integration_test.go
@@ -43,7 +43,7 @@ func TestRestartPush(t *testing.T) {
 			stopAt: 20,
 			openPushF: func(rh *restartHarness) datatransfer.ChannelID {
 				voucher := testutil.NewTestTypedVoucherWith("applesauce")
-				chid, err := rh.dt1.OpenPushDataChannel(rh.testCtx, rh.peer2, voucher, rh.rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+				chid, err := rh.dt1.OpenPushDataChannel(rh.testCtx, rh.peer2, voucher, rh.rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 				require.NoError(rh.t, err)
 				return chid
 			},
@@ -85,7 +85,7 @@ func TestRestartPush(t *testing.T) {
 			stopAt: 20,
 			openPushF: func(rh *restartHarness) datatransfer.ChannelID {
 				voucher := testutil.NewTestTypedVoucherWith("applesauce")
-				chid, err := rh.dt1.OpenPushDataChannel(rh.testCtx, rh.peer2, voucher, rh.rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+				chid, err := rh.dt1.OpenPushDataChannel(rh.testCtx, rh.peer2, voucher, rh.rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 				require.NoError(rh.t, err)
 				return chid
 			},
@@ -296,7 +296,7 @@ func TestRestartPull(t *testing.T) {
 			stopAt: 40,
 			openPullF: func(rh *restartHarness) datatransfer.ChannelID {
 				voucher := testutil.NewTestTypedVoucherWith("applesauce")
-				chid, err := rh.dt2.OpenPullDataChannel(rh.testCtx, rh.peer1, voucher, rh.rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+				chid, err := rh.dt2.OpenPullDataChannel(rh.testCtx, rh.peer1, voucher, rh.rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 				require.NoError(rh.t, err)
 				return chid
 			},
@@ -335,7 +335,7 @@ func TestRestartPull(t *testing.T) {
 			stopAt: 40,
 			openPullF: func(rh *restartHarness) datatransfer.ChannelID {
 				voucher := testutil.NewTestTypedVoucherWith("applesauce")
-				chid, err := rh.dt2.OpenPullDataChannel(rh.testCtx, rh.peer1, voucher, rh.rootCid, selectorparse.CommonSelector_ExploreAllRecursively)
+				chid, err := rh.dt2.OpenPullDataChannel(rh.testCtx, rh.peer1, voucher, rh.rootCid, selectorparse.CommonSelector_ExploreAllRecursively, nil)
 				require.NoError(rh.t, err)
 				return chid
 			},

--- a/manager.go
+++ b/manager.go
@@ -119,11 +119,11 @@ type Manager interface {
 
 	// open a data transfer that will send data to the recipient peer and
 	// transfer parts of the piece that match the selector
-	OpenPushDataChannel(ctx context.Context, to peer.ID, voucher TypedVoucher, baseCid cid.Cid, selector datamodel.Node) (ChannelID, error)
+	OpenPushDataChannel(ctx context.Context, to peer.ID, voucher TypedVoucher, baseCid cid.Cid, selector datamodel.Node, eventsCb Subscriber) (ChannelID, error)
 
 	// open a data transfer that will request data from the sending peer and
 	// transfer parts of the piece that match the selector
-	OpenPullDataChannel(ctx context.Context, to peer.ID, voucher TypedVoucher, baseCid cid.Cid, selector datamodel.Node) (ChannelID, error)
+	OpenPullDataChannel(ctx context.Context, to peer.ID, voucher TypedVoucher, baseCid cid.Cid, selector datamodel.Node, eventsCb Subscriber) (ChannelID, error)
 
 	// send an intermediate voucher as needed when the receiver sends a request for revalidation
 	SendVoucher(ctx context.Context, chid ChannelID, voucher TypedVoucher) error


### PR DESCRIPTION
Ref: https://github.com/filecoin-project/go-data-transfer/issues/355

This just adds an optional `datatransfer.Subscriber` callback to both `OpenPushDataChannel` and `OpenPullDataChannel` that provides the events just for that channel. Needed for some lassie work I'm about to PR and will reference this PR from.

This is a Draft, it's probably not what a final would look like and I think @hannahhoward should probably redo this; I just needed the API to move forward.