### PR TITLE
Support per channel transport config

### DIFF
--- a/impl/environment.go
+++ b/impl/environment.go
@@ -25,4 +25,5 @@ func (ce *channelEnvironment) ID() peer.ID {
 func (ce *channelEnvironment) CleanupChannel(chid datatransfer.ChannelID) {
 	ce.m.transport.CleanupChannel(chid)
 	ce.m.spansIndex.EndChannelSpan(chid)
+	ce.m.transportOptions.ClearOptions(chid)
 }

--- a/impl/initiating_test.go
+++ b/impl/initiating_test.go
@@ -275,12 +275,8 @@ func TestDataTransferInitiating(t *testing.T) {
 		"customizing push transfer": {
 			expectedEvents: []datatransfer.EventCode{datatransfer.Open},
 			verify: func(t *testing.T, h *harness) {
-				err := h.dt.RegisterTransportConfigurer(h.voucher.Type, func(channelID datatransfer.ChannelID, voucher datatransfer.TypedVoucher, transport datatransfer.Transport) {
-					ft, ok := transport.(*testutil.FakeTransport)
-					if !ok {
-						return
-					}
-					ft.RecordCustomizedTransfer(channelID, voucher)
+				err := h.dt.RegisterTransportConfigurer(h.voucher.Type, func(channelID datatransfer.ChannelID, voucher datatransfer.TypedVoucher) []datatransfer.TransportOption {
+					return []datatransfer.TransportOption{testutil.RecordCustomizedTransfer()}
 				})
 				require.NoError(t, err)
 				channelID, err := h.dt.OpenPushDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
@@ -288,19 +284,14 @@ func TestDataTransferInitiating(t *testing.T) {
 				require.NotEmpty(t, channelID)
 				require.Len(t, h.transport.CustomizedTransfers, 1)
 				customizedTransfer := h.transport.CustomizedTransfers[0]
-				require.Equal(t, channelID, customizedTransfer.ChannelID)
-				require.Equal(t, h.voucher, customizedTransfer.Voucher)
+				require.Equal(t, channelID, customizedTransfer)
 			},
 		},
 		"customizing pull transfer": {
 			expectedEvents: []datatransfer.EventCode{datatransfer.Open},
 			verify: func(t *testing.T, h *harness) {
-				err := h.dt.RegisterTransportConfigurer(h.voucher.Type, func(channelID datatransfer.ChannelID, voucher datatransfer.TypedVoucher, transport datatransfer.Transport) {
-					ft, ok := transport.(*testutil.FakeTransport)
-					if !ok {
-						return
-					}
-					ft.RecordCustomizedTransfer(channelID, voucher)
+				err := h.dt.RegisterTransportConfigurer(h.voucher.Type, func(channelID datatransfer.ChannelID, voucher datatransfer.TypedVoucher) []datatransfer.TransportOption {
+					return []datatransfer.TransportOption{testutil.RecordCustomizedTransfer()}
 				})
 				require.NoError(t, err)
 				channelID, err := h.dt.OpenPullDataChannel(h.ctx, h.peers[1], h.voucher, h.baseCid, h.stor)
@@ -308,8 +299,7 @@ func TestDataTransferInitiating(t *testing.T) {
 				require.NotEmpty(t, channelID)
 				require.Len(t, h.transport.CustomizedTransfers, 1)
 				customizedTransfer := h.transport.CustomizedTransfers[0]
-				require.Equal(t, channelID, customizedTransfer.ChannelID)
-				require.Equal(t, h.voucher, customizedTransfer.Voucher)
+				require.Equal(t, channelID, customizedTransfer)
 			},
 		},
 	}

--- a/impl/receiving_requests.go
+++ b/impl/receiving_requests.go
@@ -116,7 +116,12 @@ func (m *manager) acceptRequest(chid datatransfer.ChannelID, incoming datatransf
 	processor, has := m.transportConfigurers.Processor(voucher.Type)
 	if has {
 		transportConfigurer := processor.(datatransfer.TransportConfigurer)
-		transportConfigurer(chid, voucher, m.transport)
+		if options := transportConfigurer(chid, voucher); len(options) > 0 {
+			m.transportOptions.SetOptions(chid, options)
+		}
+	}
+	if err := m.transportOptions.ApplyOptions(chid, m.transport); err != nil {
+		return result, err
 	}
 	m.dataTransferNetwork.Protect(chid.Initiator, chid.String())
 
@@ -198,7 +203,12 @@ func (m *manager) restartRequest(chid datatransfer.ChannelID,
 	processor, has := m.transportConfigurers.Processor(voucherType)
 	if has {
 		transportConfigurer := processor.(datatransfer.TransportConfigurer)
-		transportConfigurer(chid, typedVoucher, m.transport)
+		if options := transportConfigurer(chid, typedVoucher); len(options) > 0 {
+			m.transportOptions.SetOptions(chid, options)
+		}
+	}
+	if err := m.transportOptions.ApplyOptions(chid, m.transport); err != nil {
+		return stayPaused, result, err
 	}
 	m.dataTransferNetwork.Protect(initiator, chid.String())
 	return stayPaused, result, nil

--- a/impl/responding_test.go
+++ b/impl/responding_test.go
@@ -598,19 +598,14 @@ func TestDataTransferResponding(t *testing.T) {
 				sv.StubResult(datatransfer.ValidationResult{Accepted: true})
 			},
 			verify: func(t *testing.T, h *receiverHarness) {
-				err := h.dt.RegisterTransportConfigurer(h.voucher.Type, func(channelID datatransfer.ChannelID, voucher datatransfer.TypedVoucher, transport datatransfer.Transport) {
-					ft, ok := transport.(*testutil.FakeTransport)
-					if !ok {
-						return
-					}
-					ft.RecordCustomizedTransfer(channelID, voucher)
+				err := h.dt.RegisterTransportConfigurer(h.voucher.Type, func(channelID datatransfer.ChannelID, voucher datatransfer.TypedVoucher) []datatransfer.TransportOption {
+					return []datatransfer.TransportOption{testutil.RecordCustomizedTransfer()}
 				})
 				require.NoError(t, err)
 				h.network.Delegate.ReceiveRequest(h.ctx, h.peers[1], h.pushRequest)
 				require.Len(t, h.transport.CustomizedTransfers, 1)
 				customizedTransfer := h.transport.CustomizedTransfers[0]
-				require.Equal(t, channelID(h.id, h.peers), customizedTransfer.ChannelID)
-				require.Equal(t, h.voucher, customizedTransfer.Voucher)
+				require.Equal(t, channelID(h.id, h.peers), customizedTransfer)
 			},
 		},
 		"new pull request, customized transport": {
@@ -623,20 +618,15 @@ func TestDataTransferResponding(t *testing.T) {
 				sv.StubResult(datatransfer.ValidationResult{Accepted: true})
 			},
 			verify: func(t *testing.T, h *receiverHarness) {
-				err := h.dt.RegisterTransportConfigurer(h.voucher.Type, func(channelID datatransfer.ChannelID, voucher datatransfer.TypedVoucher, transport datatransfer.Transport) {
-					ft, ok := transport.(*testutil.FakeTransport)
-					if !ok {
-						return
-					}
-					ft.RecordCustomizedTransfer(channelID, voucher)
+				err := h.dt.RegisterTransportConfigurer(h.voucher.Type, func(channelID datatransfer.ChannelID, voucher datatransfer.TypedVoucher) []datatransfer.TransportOption {
+					return []datatransfer.TransportOption{testutil.RecordCustomizedTransfer()}
 				})
 				require.NoError(t, err)
 				_, err = h.transport.EventHandler.OnRequestReceived(channelID(h.id, h.peers), h.pullRequest)
 				require.NoError(t, err)
 				require.Len(t, h.transport.CustomizedTransfers, 1)
 				customizedTransfer := h.transport.CustomizedTransfers[0]
-				require.Equal(t, channelID(h.id, h.peers), customizedTransfer.ChannelID)
-				require.Equal(t, h.voucher, customizedTransfer.Voucher)
+				require.Equal(t, channelID(h.id, h.peers), customizedTransfer)
 			},
 		},
 	}

--- a/impl/restart.go
+++ b/impl/restart.go
@@ -85,7 +85,12 @@ func (m *manager) openPushRestartChannel(ctx context.Context, channel datatransf
 	processor, has := m.transportConfigurers.Processor(voucher.Type)
 	if has {
 		transportConfigurer := processor.(datatransfer.TransportConfigurer)
-		transportConfigurer(chid, voucher, m.transport)
+		if options := transportConfigurer(chid, voucher); len(options) > 0 {
+			m.transportOptions.SetOptions(chid, options)
+		}
+	}
+	if err := m.transportOptions.ApplyOptions(chid, m.transport); err != nil {
+		return err
 	}
 	m.dataTransferNetwork.Protect(requestTo, chid.String())
 
@@ -120,7 +125,12 @@ func (m *manager) openPullRestartChannel(ctx context.Context, channel datatransf
 	processor, has := m.transportConfigurers.Processor(voucher.Type)
 	if has {
 		transportConfigurer := processor.(datatransfer.TransportConfigurer)
-		transportConfigurer(chid, voucher, m.transport)
+		if options := transportConfigurer(chid, voucher); len(options) > 0 {
+			m.transportOptions.SetOptions(chid, options)
+		}
+	}
+	if err := m.transportOptions.ApplyOptions(chid, m.transport); err != nil {
+		return err
 	}
 	m.dataTransferNetwork.Protect(requestTo, chid.String())
 

--- a/manager.go
+++ b/manager.go
@@ -90,7 +90,7 @@ type RequestValidator interface {
 }
 
 // TransportConfigurer provides a mechanism to provide transport specific configuration for a given voucher type
-type TransportConfigurer func(chid ChannelID, voucher TypedVoucher, transport Transport)
+type TransportConfigurer func(chid ChannelID, voucher TypedVoucher) []TransportOption
 
 // ReadyFunc is function that gets called once when the data transfer module is ready
 type ReadyFunc func(error)

--- a/transferconfig.go
+++ b/transferconfig.go
@@ -1,11 +1,18 @@
 package datatransfer
 
+type TransportOption func(chid ChannelID, transport Transport) error
+
 type transferConfig struct {
-	eventsCb Subscriber
+	eventsCb         Subscriber
+	transportOptions []TransportOption
 }
 
 func (tc *transferConfig) EventsCb() Subscriber {
 	return tc.eventsCb
+}
+
+func (tc *transferConfig) TransportOptions() []TransportOption {
+	return tc.transportOptions
 }
 
 // TransferOption customizes a single transfer
@@ -18,9 +25,16 @@ func WithSubscriber(eventsCb Subscriber) TransferOption {
 	}
 }
 
+func WithTransportOptions(transportOptions ...TransportOption) TransferOption {
+	return func(tc *transferConfig) {
+		tc.transportOptions = transportOptions
+	}
+}
+
 // TransferConfig accesses transfer properties
 type TransferConfig interface {
 	EventsCb() Subscriber
+	TransportOptions() []TransportOption
 }
 
 // FromOptions builds a config from an options list

--- a/transport/graphsync/graphsync.go
+++ b/transport/graphsync/graphsync.go
@@ -337,6 +337,19 @@ func (t *Transport) Shutdown(ctx context.Context) error {
 	return nil
 }
 
+func UseStore(store ipld.LinkSystem) datatransfer.TransportOption {
+	return func(channelID datatransfer.ChannelID, transport datatransfer.Transport) error {
+		gsTransport, ok := transport.(*Transport)
+		if !ok {
+			return datatransfer.ErrUnsupported
+		}
+		if err := gsTransport.UseStore(channelID, store); err != nil {
+			log.Errorf("attempting to configure data store: %s", err.Error())
+		}
+		return nil
+	}
+}
+
 // UseStore tells the graphsync transport to use the given loader and storer for this channelID
 func (t *Transport) UseStore(channelID datatransfer.ChannelID, lsys ipld.LinkSystem) error {
 	ch := t.trackDTChannel(channelID)

--- a/transportoptions/transportoptions.go
+++ b/transportoptions/transportoptions.go
@@ -1,0 +1,52 @@
+package transportoptions
+
+import (
+	"fmt"
+	"sync"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer/v2"
+)
+
+type TransportOptions struct {
+	optionsLk sync.RWMutex
+	options   map[datatransfer.ChannelID][]datatransfer.TransportOption
+}
+
+func NewTransportOptions() *TransportOptions {
+	return &TransportOptions{
+		options: make(map[datatransfer.ChannelID][]datatransfer.TransportOption),
+	}
+}
+
+func (to *TransportOptions) SetOptions(chid datatransfer.ChannelID, options []datatransfer.TransportOption) {
+	to.optionsLk.Lock()
+	to.options[chid] = options
+	to.optionsLk.Unlock()
+}
+
+func (to *TransportOptions) ApplyOptions(chid datatransfer.ChannelID, transport datatransfer.Transport) error {
+	to.optionsLk.RLock()
+	defer to.optionsLk.RUnlock()
+
+	for _, transportOption := range to.options[chid] {
+		err := transportOption(chid, transport)
+		if err != nil {
+			return fmt.Errorf("applying transport option: %w", err)
+		}
+	}
+	return nil
+}
+
+func (to *TransportOptions) ClearOptions(chid datatransfer.ChannelID) {
+	to.optionsLk.Lock()
+	defer to.optionsLk.Unlock()
+	delete(to.options, chid)
+
+}
+
+func (to *TransportOptions) ClearAll() {
+	to.optionsLk.Lock()
+	defer to.optionsLk.Unlock()
+	// reset in case someone continues to use the span index
+	to.options = make(map[datatransfer.ChannelID][]datatransfer.TransportOption)
+}


### PR DESCRIPTION
# Goals

This aims to import transport configuration by allowing a configuration when opening a channel. 

You can now pass WithTransportOptions, and then use options provided by your chose transport.

# Implementation

- track transport options in a simple mutex protected array
- **BREAKING** (but hey, it's go-data-transfer v2 which is still RC) - change the signature of RegisterTransportConfigurer, which was super weird, to return TransportOptions -- this reduces what the calling library has to do.
- Transports themselves now provide options which makes for MUCH cleaner usage.

# For Discussion

This implementation is... not quite perfect, but I think good enough for Lassie + go-fil-markets, the consumers.

The interaction between the old mechanism and the new mechanism is somewhat conflicting, and once I tried to replace the old mechanism completely, I ran into many of the perpetual design problems I struggle with in this library:
- how to support restarts after a reboot (i.e. from disk)
- how to support configure transfers for the receiver of an incoming request
- rather than go down yet another design hole like I did with the transport refactor that never got finished, I decided to call this good enough.

Companion PR for go-fil-markets: https://github.com/filecoin-project/go-fil-markets/pull/780