### PR TITLE
Make states/events printable

### DIFF
--- a/events.go
+++ b/events.go
@@ -1,6 +1,8 @@
 package datatransfer
 
-import "time"
+import (
+	"time"
+)
 
 // EventCode is a name for an event that occurs on a data transfer channel
 type EventCode int
@@ -169,6 +171,10 @@ var Events = map[EventCode]string{
 	DataLimitExceeded:           "DataLimitExceeded",
 	TransferInitiated:           "TransferInitiated",
 	SendMessageError:            "SendMessageError",
+}
+
+func (e EventCode) String() string {
+	return Events[e]
 }
 
 // Event is a struct containing information about a data transfer event

--- a/printing_test.go
+++ b/printing_test.go
@@ -1,0 +1,19 @@
+package datatransfer_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer/v2"
+)
+
+func TestPrinting(t *testing.T) {
+	for key, value := range datatransfer.Events {
+		require.Equal(t, fmt.Sprintf("%v", key), value)
+	}
+	for key, value := range datatransfer.Statuses {
+		require.Equal(t, fmt.Sprintf("%v", key), value)
+	}
+}

--- a/statuses.go
+++ b/statuses.go
@@ -102,6 +102,9 @@ var NotAcceptedStates = statusList{
 func (s Status) IsAccepted() bool {
 	return !NotAcceptedStates.Contains(s)
 }
+func (s Status) String() string {
+	return Statuses[s]
+}
 
 var FinalizationStatuses = statusList{Finalizing, Completed, Completing}
 


### PR DESCRIPTION
# Goals

Resolves a long standing Quality Of Life improvement -- adds a fmt.Stringer methods to status and events so they appear in readable form when the state machine fails

I have no idea why I didn't do this earlier.