### PR TITLE
Fix races in tests

### DIFF
--- a/impl/initiating_test.go
+++ b/impl/initiating_test.go
@@ -205,9 +205,13 @@ func TestDataTransferInitiating(t *testing.T) {
 				require.Equal(t, h.transport.ClosedChannels[0], channelID)
 
 				require.Eventually(t, func() bool {
+					h.network.SentMessagesLk.Lock()
+					defer h.network.SentMessagesLk.Unlock()
 					return len(h.network.SentMessages) == 2
 				}, 5*time.Second, 200*time.Millisecond)
+				h.network.SentMessagesLk.Lock()
 				cancelMessage := h.network.SentMessages[1].Message
+				h.network.SentMessagesLk.Unlock()
 				require.False(t, cancelMessage.IsUpdate())
 				require.False(t, cancelMessage.IsPaused())
 				require.True(t, cancelMessage.IsRequest())
@@ -261,10 +265,14 @@ func TestDataTransferInitiating(t *testing.T) {
 				require.Equal(t, h.transport.ClosedChannels[0], channelID)
 
 				require.Eventually(t, func() bool {
+					h.network.SentMessagesLk.Lock()
+					defer h.network.SentMessagesLk.Unlock()
 					return len(h.network.SentMessages) == 1
 				}, 5*time.Second, 200*time.Millisecond)
 
+				h.network.SentMessagesLk.Lock()
 				cancelMessage := h.network.SentMessages[0].Message
+				h.network.SentMessagesLk.Unlock()
 				require.False(t, cancelMessage.IsUpdate())
 				require.False(t, cancelMessage.IsPaused())
 				require.True(t, cancelMessage.IsRequest())

--- a/impl/responding_test.go
+++ b/impl/responding_test.go
@@ -352,6 +352,8 @@ func TestDataTransferResponding(t *testing.T) {
 				h.network.Delegate.ReceiveRequest(h.ctx, h.peers[1], h.pushRequest)
 				_, err := h.transport.EventHandler.OnRequestReceived(channelID(h.id, h.peers), h.cancelUpdate)
 				require.NoError(t, err)
+				h.transport.TransportLk.Lock()
+				defer h.transport.TransportLk.Unlock()
 				require.Len(t, h.transport.CleanedUpChannels, 1)
 				require.Equal(t, channelID(h.id, h.peers), h.transport.CleanedUpChannels[0])
 			},

--- a/testutil/testnet.go
+++ b/testutil/testnet.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"context"
+	"sync"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -19,9 +20,10 @@ type FakeSentMessage struct {
 // FakeNetwork is a network that satisfies the DataTransferNetwork interface but
 // does not actually do anything
 type FakeNetwork struct {
-	PeerID       peer.ID
-	SentMessages []FakeSentMessage
-	Delegate     network.Receiver
+	PeerID         peer.ID
+	SentMessagesLk sync.Mutex
+	SentMessages   []FakeSentMessage
+	Delegate       network.Receiver
 }
 
 // NewFakeNetwork returns a new fake data transfer network instance
@@ -33,6 +35,8 @@ var _ network.DataTransferNetwork = (*FakeNetwork)(nil)
 
 // SendMessage sends a GraphSync message to a peer.
 func (fn *FakeNetwork) SendMessage(ctx context.Context, p peer.ID, m datatransfer.Message) error {
+	fn.SentMessagesLk.Lock()
+	defer fn.SentMessagesLk.Unlock()
 	fn.SentMessages = append(fn.SentMessages, FakeSentMessage{p, m})
 	return nil
 }

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	blocks "github.com/ipfs/go-block-format"
@@ -24,12 +25,16 @@ var blockGenerator = blocksutil.NewBlockGenerator()
 
 // var prioritySeq int
 var seedSeq int64
+var seedLock sync.Mutex
 
 // RandomBytes returns a byte array of the given size with random values.
 func RandomBytes(n int64) []byte {
 	data := new(bytes.Buffer)
-	random.WritePseudoRandomBytes(n, data, seedSeq) // nolint: gosec,errcheck
+	seedLock.Lock()
+	currentSeedSeq := seedSeq
 	seedSeq++
+	seedLock.Unlock()
+	random.WritePseudoRandomBytes(n, data, currentSeedSeq) // nolint: gosec,errcheck
 	return data.Bytes()
 }
 


### PR DESCRIPTION
once upon a time I decided to run all the tests with go test --race. Apparently, there are problems.