### PR TITLE
fix: expose and use statemachine stop

### DIFF
--- a/channels/channels.go
+++ b/channels/channels.go
@@ -89,6 +89,11 @@ func (c *Channels) Start(ctx context.Context) error {
 	return c.migrateStateMachines(ctx)
 }
 
+// Stop stops the channel statemachine
+func (c *Channels) Stop(ctx context.Context) error {
+	return c.stateMachines.Stop(ctx)
+}
+
 func (c *Channels) dispatch(eventName fsm.EventName, channel fsm.StateType) {
 	evtCode, ok := eventName.(datatransfer.EventCode)
 	if !ok {

--- a/impl/impl.go
+++ b/impl/impl.go
@@ -165,6 +165,7 @@ func (m *manager) Stop(ctx context.Context) error {
 	m.spansIndex.EndAll()
 	m.transportOptions.ClearAll()
 	m.channelSubscriptions.Stop()
+	m.channels.Stop(ctx)
 	return m.transport.Shutdown(ctx)
 }
 


### PR DESCRIPTION
only important if you want to fully cleanup after starting and stopping a datatransfer manager